### PR TITLE
Fix typos in essence pouch comment

### DIFF
--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/items/essencepouch/EssencePouch.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/items/essencepouch/EssencePouch.kt
@@ -4,7 +4,7 @@ package org.alter.plugins.content.items.other.essencepouch
  * @author Triston Plummer ("Dread')
  *
  * @param id        The essence pouch item id
- * @param levelReq  The Ruencrafting level required to use the pouch
- * @param capacity  The maximum capacity of theessence pouch
+ * @param levelReq  The Runecrafting level required to use the pouch
+ * @param capacity  The maximum capacity of the essence pouch
  */
 data class EssencePouch(val id: Int, val levelReq: Int, val capacity: Int)


### PR DESCRIPTION
## Summary
- fix typos in `EssencePouch.kt` doc comment

## Testing
- `gradle --version`

------
https://chatgpt.com/codex/tasks/task_e_6840521179488329bcf95534f48e7c56