### PR TITLE
fix: correct log message format in ItemContainer#set

### DIFF
--- a/game-server/src/main/kotlin/org/alter/game/model/container/ItemContainer.kt
+++ b/game-server/src/main/kotlin/org/alter/game/model/container/ItemContainer.kt
@@ -300,7 +300,7 @@ class ItemContainer(val definitions: DefinitionSet, val key: ContainerKey) : Ite
             items[index] = item
             dirty = true
         } else {
-            logger.warn { "Invalid set(): slot index $index out of bounds (0..${capacity - 1}}), item=$item" }
+            logger.warn { "Invalid set(): slot index $index out of bounds (0..${capacity - 1}), item=$item" }
         }
     }
 


### PR DESCRIPTION
## Summary
- correct the log message when calling `set` with an invalid slot

## Testing
- `gradle test` *(fails: Could not determine the dependencies of task ':test'. Toolchain download repositories have not been configured)*

------
https://chatgpt.com/codex/tasks/task_e_68405212bdec8329bbb8ee42c138ff51