### PR TITLE
Randomize Abomination respawn location

### DIFF
--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/other/abomination_lvl149.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/other/abomination_lvl149.plugin.kts
@@ -2,10 +2,22 @@ package org.alter.plugins.content.npcs.other
 
 import org.alter.plugins.content.combat.isBeingAttacked
 import org.alter.plugins.content.drops.DropTableFactory
+import org.alter.game.model.Tile
 
 set_multi_combat_region(region = 13472)
 
-spawn_npc(Npcs.ABOMINATION_8262, x = 2274, z = 4698, walkRadius = 5)
+spawn_npc(Npcs.ABOMINATION_8262, x = 3361, z = 10274, walkRadius = 5)
+
+val spawnLocations = listOf(
+    Tile(x = 3361, z = 10274, height = 0),
+    Tile(x = 3381, z = 10286, height = 0),
+    Tile(x = 3359, z = 10246, height = 0),
+    Tile(x = 3338, z = 10286, height = 0)
+)
+
+on_npc_spawn(npc = Npcs.ABOMINATION_8262) {
+    npc.moveTo(spawnLocations.random())
+}
 
 val ids = intArrayOf(
     Npcs.ABOMINATION_8262


### PR DESCRIPTION
## Summary
- spawn the Abomination in Mort'ton
- choose a random location from four possible spots whenever the NPC spawns

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 gradle build` *(fails: Could not determine the dependencies of task ':compileKotlin')*

------
https://chatgpt.com/codex/tasks/task_e_6841cced4d8083299f5d3bc5b13e0188