### PR TITLE
Add basic Barrows minigame skeleton

### DIFF
--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/area/legacy/barrows/Barrows.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/area/legacy/barrows/Barrows.kt
@@ -1,0 +1,22 @@
+package org.alter.plugins.content.area.legacy.barrows
+
+import org.alter.game.model.attr.AttributeKey
+import org.alter.game.model.Tile
+
+object Barrows {
+    // bit flags for each brother in order: Dharok, Verac, Ahrim, Guthan, Karil, Torag
+    val PROGRESS_ATTR = AttributeKey<Int>(persistenceKey = "barrows_progress")
+
+    data class Brother(val id: Int, val mound: Tile, val crypt: Tile)
+
+    val BROTHERS = listOf(
+        Brother(org.alter.api.cfg.Npcs.DHAROK_THE_WRETCHED, Tile(3575, 3297), Tile(3575, 9703, 3)),
+        Brother(org.alter.api.cfg.Npcs.VERAC_THE_DEFILED, Tile(3556, 3297), Tile(3556, 9701, 3)),
+        Brother(org.alter.api.cfg.Npcs.AHRIM_THE_BLIGHTED, Tile(3565, 3288), Tile(3565, 9708, 3)),
+        Brother(org.alter.api.cfg.Npcs.GUTHAN_THE_INFESTED, Tile(3575, 3282), Tile(3575, 9694, 3)),
+        Brother(org.alter.api.cfg.Npcs.KARIL_THE_TAINTED, Tile(3565, 3275), Tile(3565, 9683, 3)),
+        Brother(org.alter.api.cfg.Npcs.TORAG_THE_CORRUPTED, Tile(3553, 3282), Tile(3553, 9689, 3)),
+    )
+
+    const val CHEST = 20973
+}

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/area/legacy/barrows/chest.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/area/legacy/barrows/chest.plugin.kts
@@ -1,0 +1,19 @@
+package org.alter.plugins.content.area.legacy.barrows
+
+import org.alter.api.cfg.Objs
+import org.alter.api.cfg.Items
+import org.alter.plugins.content.area.legacy.barrows.Barrows
+
+on_obj_option(obj = Barrows.CHEST, option = "open") {
+    val completed = (1 shl Barrows.BROTHERS.size) - 1
+    val progress = player.attr[Barrows.PROGRESS_ATTR] ?: 0
+    if (progress != completed) {
+        player.message("The chest is empty.")
+        return@on_obj_option
+    }
+    player.attr[Barrows.PROGRESS_ATTR] = 0
+    player.inventory.add(Items.BOLT_RACK, 50)
+    player.inventory.add(Items.DEATH_RUNE, 100)
+    player.inventory.add(Items.BLOOD_RUNE, 100)
+    player.message("You loot the chest and feel a strange power fade.")
+}

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/area/legacy/barrows/crypts.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/area/legacy/barrows/crypts.plugin.kts
@@ -1,0 +1,22 @@
+package org.alter.plugins.content.area.legacy.barrows
+
+import org.alter.api.cfg.Items
+import org.alter.game.model.entity.Npc
+import org.alter.game.model.entity.Player
+import org.alter.plugins.content.area.legacy.barrows.Barrows
+
+Barrows.BROTHERS.forEachIndexed { index, brother ->
+    on_item_option(item = Items.SPADE, option = "dig") {
+        if (player.tile.withinRadius(brother.mound, 1)) {
+            val npc = Npc(brother.id, brother.crypt, world)
+            world.spawn(npc)
+            return@on_item_option
+        }
+    }
+
+    on_npc_death(brother.id) {
+        val killer = npc.damageMap.getMostDamage() as? Player ?: return@on_npc_death
+        val flags = killer.attr[Barrows.PROGRESS_ATTR] ?: 0
+        killer.attr[Barrows.PROGRESS_ATTR] = flags or (1 shl index)
+    }
+}

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/area/legacy/barrows/entrance.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/area/legacy/barrows/entrance.plugin.kts
@@ -1,0 +1,15 @@
+package org.alter.plugins.content.area.legacy.barrows
+
+import org.alter.api.cfg.Items
+import org.alter.plugins.content.area.legacy.barrows.Barrows
+
+on_item_option(item = Items.SPADE, "dig") {
+    val loc = player.tile
+    Barrows.BROTHERS.forEachIndexed { index, brother ->
+        if (loc.withinRadius(brother.mound, 1)) {
+            player.animate(830)
+            player.teleport(brother.crypt)
+            return@on_item_option
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Barrows constants and helper object
- implement spade digging teleport
- spawn brothers in crypts and track progress
- reward basic loot from chest

## Testing
- `gradle test` *(fails: Could not find Oracle JDK toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_6841ca07559c83299610dd0398489da7