### PR TITLE
Expand barrows mechanics

### DIFF
--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/area/legacy/barrows/Barrows.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/area/legacy/barrows/Barrows.kt
@@ -6,6 +6,7 @@ import org.alter.game.model.Tile
 object Barrows {
     // bit flags for each brother in order: Dharok, Verac, Ahrim, Guthan, Karil, Torag
     val PROGRESS_ATTR = AttributeKey<Int>(persistenceKey = "barrows_progress")
+    val LAST_BROTHER_ATTR = AttributeKey<Int>(persistenceKey = "barrows_last")
 
     data class Brother(val id: Int, val mound: Tile, val crypt: Tile)
 
@@ -18,5 +19,6 @@ object Barrows {
         Brother(org.alter.api.cfg.Npcs.TORAG_THE_CORRUPTED, Tile(3553, 3282), Tile(3553, 9689, 3)),
     )
 
-    const val CHEST = 20973
+    const val CHEST = 20723
+    const val TUNNEL_INDEX = 5
 }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/area/legacy/barrows/chest.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/area/legacy/barrows/chest.plugin.kts
@@ -2,18 +2,41 @@ package org.alter.plugins.content.area.legacy.barrows
 
 import org.alter.api.cfg.Objs
 import org.alter.api.cfg.Items
+import org.alter.game.model.entity.Npc
+import org.alter.plugins.content.drops.DropTableFactory
+import org.alter.plugins.content.drops.DropTableType
 import org.alter.plugins.content.area.legacy.barrows.Barrows
 
 on_obj_option(obj = Objs.CHEST_20723, option = "open") {
     val completed = (1 shl Barrows.BROTHERS.size) - 1
     val progress = player.attr[Barrows.PROGRESS_ATTR] ?: 0
-    if (progress != completed) {
-        player.message("The chest is empty.")
+    val missing = Barrows.BROTHERS.indices.filter { progress and (1 shl it) == 0 }
+
+    if (progress == completed) {
+        player.attr[Barrows.PROGRESS_ATTR] = 0
+        val drops = DropTableFactory.getDrop(player, Barrows.CHEST, DropTableType.CHEST)?.shuffled()?.take(3)
+        drops?.forEach { player.inventory.add(it) }
+        val last = player.attr[Barrows.LAST_BROTHER_ATTR]
+        if (last != null) {
+            DropTableFactory.getDrop(player, Barrows.BROTHERS[last].id, DropTableType.CHEST)
+                ?.firstOrNull()?.let { player.inventory.add(it) }
+        }
+        player.message("You loot the chest and feel a strange power fade.")
         return@on_obj_option
     }
-    player.attr[Barrows.PROGRESS_ATTR] = 0
-    player.inventory.add(Items.BOLT_RACK, 50)
-    player.inventory.add(Items.DEATH_RUNE, 100)
-    player.inventory.add(Items.BLOOD_RUNE, 100)
-    player.message("You loot the chest and feel a strange power fade.")
+
+    if (missing.size == 1) {
+        val index = missing.first()
+        val brother = Barrows.BROTHERS[index]
+        val spawned = world.npcs.any { it.owner == player && it.id == brother.id }
+        if (!spawned) {
+            val npc = Npc(player, brother.id, player.tile.transform(1, 0), world)
+            npc.respawns = false
+            world.spawn(npc)
+            player.message("A Barrows brother emerges from the shadows!")
+        }
+        return@on_obj_option
+    }
+
+    player.message("The chest is sealed shut.")
 }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/area/legacy/barrows/crypts.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/area/legacy/barrows/crypts.plugin.kts
@@ -10,5 +10,6 @@ Barrows.BROTHERS.forEachIndexed { index, brother ->
         val killer = npc.damageMap.getMostDamage() as? Player ?: return@on_npc_death
         val flags = killer.attr[Barrows.PROGRESS_ATTR] ?: 0
         killer.attr[Barrows.PROGRESS_ATTR] = flags or (1 shl index)
+        killer.attr[Barrows.LAST_BROTHER_ATTR] = index
     }
 }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/area/legacy/barrows/drops.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/area/legacy/barrows/drops.plugin.kts
@@ -1,0 +1,90 @@
+package org.alter.plugins.content.area.legacy.barrows
+
+import org.alter.api.cfg.Items
+import org.alter.api.cfg.Npcs
+import org.alter.plugins.content.drops.DropTableFactory
+import org.alter.plugins.content.drops.DropTableType
+
+val chestTable = DropTableFactory.build {
+    main {
+        total(128)
+        obj(Items.DEATH_RUNE, quantityRange = 30..100, slots = 16)
+        obj(Items.BLOOD_RUNE, quantityRange = 30..100, slots = 16)
+        obj(Items.CHAOS_RUNE, quantityRange = 50..150, slots = 16)
+        obj(Items.MIND_RUNE, quantityRange = 50..150, slots = 16)
+        obj(Items.BOLT_RACK, quantityRange = 50..100, slots = 16)
+        obj(Items.COINS_995, quantityRange = 1000..5000, slots = 16)
+        nothing(48)
+    }
+}
+
+DropTableFactory.register(chestTable, Barrows.CHEST, type = DropTableType.CHEST)
+
+private val brotherTables = arrayOf(
+    DropTableFactory.build {
+        main {
+            total(128)
+            obj(Items.DHAROKS_HELM)
+            obj(Items.DHAROKS_GREATAXE)
+            obj(Items.DHAROKS_PLATEBODY)
+            obj(Items.DHAROKS_PLATELEGS)
+            nothing(124)
+        }
+    },
+    DropTableFactory.build {
+        main {
+            total(128)
+            obj(Items.VERACS_HELM)
+            obj(Items.VERACS_FLAIL)
+            obj(Items.VERACS_BRASSARD)
+            obj(Items.VERACS_PLATESKIRT)
+            nothing(124)
+        }
+    },
+    DropTableFactory.build {
+        main {
+            total(128)
+            obj(Items.AHRIMS_HOOD)
+            obj(Items.AHRIMS_STAFF)
+            obj(Items.AHRIMS_ROBETOP)
+            obj(Items.AHRIMS_ROBESKIRT)
+            nothing(124)
+        }
+    },
+    DropTableFactory.build {
+        main {
+            total(128)
+            obj(Items.GUTHANS_HELM)
+            obj(Items.GUTHANS_WARSPEAR)
+            obj(Items.GUTHANS_PLATEBODY)
+            obj(Items.GUTHANS_CHAINSKIRT)
+            nothing(124)
+        }
+    },
+    DropTableFactory.build {
+        main {
+            total(128)
+            obj(Items.KARILS_COIF)
+            obj(Items.KARILS_CROSSBOW)
+            obj(Items.KARILS_LEATHERTOP)
+            obj(Items.KARILS_LEATHERSKIRT)
+            nothing(124)
+        }
+    },
+    DropTableFactory.build {
+        main {
+            total(128)
+            obj(Items.TORAGS_HELM)
+            obj(Items.TORAGS_HAMMERS)
+            obj(Items.TORAGS_PLATEBODY)
+            obj(Items.TORAGS_PLATELEGS)
+            nothing(124)
+        }
+    }
+)
+
+Barrows.BROTHERS.forEachIndexed { idx, brother ->
+    DropTableFactory.register(brotherTables[idx], brother.id, type = DropTableType.CHEST)
+}
+
+val BROTHER_TABLE_IDS = Barrows.BROTHERS.map { it.id }.toIntArray()

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/area/legacy/barrows/sarcophagus.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/area/legacy/barrows/sarcophagus.plugin.kts
@@ -1,0 +1,32 @@
+package org.alter.plugins.content.area.legacy.barrows
+
+import org.alter.api.cfg.Objs
+import org.alter.game.model.Tile
+import org.alter.game.model.entity.Npc
+
+private val SARCOPHAGI = intArrayOf(Objs.SARCOPHAGUS_20720, Objs.SARCOPHAGUS_20721, Objs.SARCOPHAGUS_20722)
+
+SARCOPHAGI.forEach { sarc ->
+    on_obj_option(obj = sarc, option = "search") {
+        val index = Barrows.BROTHERS.indexOfFirst { player.tile.isWithinRadius(it.crypt, 2) }
+        if (index == -1) {
+            player.message("You find nothing of interest.")
+            return@on_obj_option
+        }
+        if (index == Barrows.TUNNEL_INDEX) {
+            player.moveTo(Tile(3551, 9691))
+            return@on_obj_option
+        }
+        val progress = player.attr[Barrows.PROGRESS_ATTR] ?: 0
+        if (progress and (1 shl index) != 0) {
+            player.message("The sarcophagus is empty.")
+            return@on_obj_option
+        }
+        val spawned = world.npcs.any { it.owner == player && it.id == Barrows.BROTHERS[index].id }
+        if (!spawned) {
+            val npc = Npc(player, Barrows.BROTHERS[index].id, player.tile.transform(1, 0), world)
+            npc.respawns = false
+            world.spawn(npc)
+        }
+    }
+}

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/items/spade/spade.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/items/spade/spade.plugin.kts
@@ -9,16 +9,17 @@ on_item_option(item = Items.SPADE, "dig") {
     val loc = player.tile
 
     // 1) Barrows-logica: 1 loop, in plaats van twee
-    Barrows.BROTHERS.forEach { brother ->
+    Barrows.BROTHERS.forEachIndexed { index, brother ->
         if (loc.isWithinRadius(brother.mound, 1)) {
-            // Kijk eerst of er al een NPC bij de crypte staat:
-            val alreadySpawned = world.npcs.any { it.id == brother.id && it.tile == brother.crypt }
-            if (!alreadySpawned) {
-                // Spawn de Barrows-broeder als hij er nog niet is
-                val npc = Npc(brother.id, brother.crypt, world)
-                world.spawn(npc)
+            val flags = player.attr[Barrows.PROGRESS_ATTR] ?: 0
+            if (flags and (1 shl index) == 0) {
+                val alreadySpawned = world.npcs.any { it.owner == player && it.id == brother.id }
+                if (!alreadySpawned) {
+                    val npc = Npc(player, brother.id, brother.crypt, world)
+                    npc.respawns = false
+                    world.spawn(npc)
+                }
             }
-            // Verplaats de speler naar de crypte, ongeacht of we net gespawnd hebben
             player.moveTo(brother.crypt)
             return@on_item_option
         }


### PR DESCRIPTION
## Summary
- keep track of the last defeated barrows brother
- spawn brothers privately when digging or searching sarcophagi
- spawn the final brother from the chest and add chest loot tables
- add barrows drop tables for chest and brothers

## Testing
- `gradle test` *(fails: Could not resolve toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_6841f6fcb6908329abf33b5940bf9366