### PR TITLE
Enable friend chat packet handlers

### DIFF
--- a/data/packets.yml
+++ b/data/packets.yml
@@ -144,9 +144,9 @@ server-packets:
         type: BYTES
 
 
-#    - message: org.alter.game.message.impl.FriendListLoadedMessage
-#      type: VARIABLE_SHORT
-#      opcode: 73
+  - message: org.alter.game.message.impl.FriendListLoadedMessage
+    type: VARIABLE_SHORT
+    opcode: 73
 
   - message: org.alter.game.message.impl.UpdateRunEnergyMessage
     type: FIXED
@@ -1281,13 +1281,13 @@ client-packets:
       - name: unknown
         type: BYTE
 
-  #  - message: org.alter.game.message.impl.IgnoreListDeleteMessage
-  #    type: VARIABLE_BYTE
-  #    opcode: 86
-  #    length: -1
-  #    structure:
-  #      - name: name
-  #        type: STRING
+  - message: org.alter.game.message.impl.IgnoreListDeleteMessage
+    type: VARIABLE_BYTE
+    opcode: 86
+    length: -1
+    structure:
+      - name: name
+        type: STRING
 
   - message: org.alter.game.message.impl.IgnoreMessage # TODO: FREECAM_EXIT
     type: FIXED
@@ -1358,13 +1358,13 @@ client-packets:
       - name: x
         type: SHORT
 
-  #  - message: org.alter.game.message.impl.FriendListDeleteMessage
-  #    type: VARIABLE_BYTE
-  #    opcode: 43
-  #    length: -1
-  #    structure:
-  #      - name: name
-  #        type: STRING
+  - message: org.alter.game.message.impl.FriendListDeleteMessage
+    type: VARIABLE_BYTE
+    opcode: 43
+    length: -1
+    structure:
+      - name: name
+        type: STRING
   #
   - message: org.alter.game.message.impl.OpPlayerTMessage
     type: FIXED
@@ -1477,20 +1477,20 @@ client-packets:
         type: BYTE
         trans: NEGATE
 
-    #  - message: org.alter.game.message.impl.FriendListAddMessage
-    #    type: VARIABLE_BYTE
-    #    opcode: 50
-    #    length: -1
-    #    structure:
-    #      - name: name
-    #        type: STRING
-    #
-    #  - message: org.alter.game.message.impl.IgnoreListAddMessage
-    #    type: VARIABLE_BYTE
-    #    opcode: 11
-    #    structure:
-    #      - name: name
-    #        type: STRING
+  - message: org.alter.game.message.impl.FriendListAddMessage
+    type: VARIABLE_BYTE
+    opcode: 50
+    length: -1
+    structure:
+      - name: name
+        type: STRING
+
+  - message: org.alter.game.message.impl.IgnoreListAddMessage
+    type: VARIABLE_BYTE
+    opcode: 11
+    structure:
+      - name: name
+        type: STRING
 
     # @Done
   - message: org.alter.game.message.impl.IgnoreMessage # TODO: REFLECTION_CHECK_REPLY

--- a/game-server/src/main/kotlin/org/alter/game/message/MessageDecoderSet.kt
+++ b/game-server/src/main/kotlin/org/alter/game/message/MessageDecoderSet.kt
@@ -101,11 +101,11 @@ class MessageDecoderSet {
         put(OpPlayer8Message::class.java, OpPlayer8Decoder(), OpPlayer8Handler(), structures)
         put(OpPlayerTMessage::class.java, OpPlayerTDecoder(), OpPlayerTHandler(), structures)
 
-        //put(FriendListAddMessage::class.java, FriendListAddDecoder(), FriendListAddHandler(), structures)
-        //put(FriendListDeleteMessage::class.java, FriendListDeleteDecoder(), FriendListDeleteHandler(), structures)
-        //put(IgnoreListAddMessage::class.java, IgnoreListAddDecoder(), IgnoreListAddHandler(), structures)
-        //put(IgnoreListDeleteMessage::class.java, IgnoreListDeleteDecoder(), IgnoreListDeleteHandler(), structures)
-        //put(MessagePrivateSenderMessage::class.java, MessagePrivateSenderDecoder(), MessagePrivateSenderHandler(), structures)
+        put(FriendListAddMessage::class.java, FriendListAddDecoder(), FriendListAddHandler(), structures)
+        put(FriendListDeleteMessage::class.java, FriendListDeleteDecoder(), FriendListDeleteHandler(), structures)
+        put(IgnoreListAddMessage::class.java, IgnoreListAddDecoder(), IgnoreListAddHandler(), structures)
+        put(IgnoreListDeleteMessage::class.java, IgnoreListDeleteDecoder(), IgnoreListDeleteHandler(), structures)
+        put(MessagePrivateSenderMessage::class.java, MessagePrivateSenderDecoder(), MessagePrivateSenderHandler(), structures)
 
     }
 


### PR DESCRIPTION
## Summary
- enable friend list and ignore list decoders/handlers
- un-comment packet definitions for friend and ignore lists

## Testing
- `gradle build -x test` *(fails: Could not find JDK 17 for toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_684c8acbb5588329aef251121ccce75b