### PR TITLE
Fix Barrows tunnel randomization per player

### DIFF
--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/area/legacy/barrows/Barrows.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/area/legacy/barrows/Barrows.kt
@@ -8,6 +8,7 @@ object Barrows {
     // bit flags for each brother in order: Dharok, Verac, Ahrim, Guthan, Karil, Torag
     val PROGRESS_ATTR = AttributeKey<Int>(persistenceKey = "barrows_progress")
     val LAST_BROTHER_ATTR = AttributeKey<Int>(persistenceKey = "barrows_last")
+    val TUNNEL_ATTR = AttributeKey<Int>(persistenceKey = "barrows_tunnel")
 
     data class Brother(val id: Int, val mound: Tile, val crypt: Tile)
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/area/legacy/barrows/chest.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/area/legacy/barrows/chest.plugin.kts
@@ -22,6 +22,7 @@ on_obj_option(obj = Objs.CHEST_20723, option = "open") {
                 ?.firstOrNull()?.let { player.inventory.add(it) }
         }
         player.attr.remove(Barrows.LAST_BROTHER_ATTR)
+        player.attr.remove(Barrows.TUNNEL_ATTR)
         player.message("You loot the chest and feel a strange power fade.")
         return@on_obj_option
     }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/area/legacy/barrows/sarcophagus.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/area/legacy/barrows/sarcophagus.plugin.kts
@@ -12,7 +12,8 @@ private val SARCOPHAGI = Barrows.SARCOPHAGUS_IDS
 SARCOPHAGI.forEachIndexed { index, sarc ->
     listOf("Search").forEach { opt ->
         on_obj_option(obj = sarc, option = opt) {
-            if (index == Barrows.TUNNEL_INDEX) {
+            val tunnelIndex = player.attr[Barrows.TUNNEL_ATTR] ?: Barrows.TUNNEL_INDEX
+            if (index == tunnelIndex) {
                 player.moveTo(Tile(3551, 9691))
                 return@on_obj_option
             }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/items/spade/spade.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/items/spade/spade.plugin.kts
@@ -7,6 +7,11 @@ on_item_option(item = Items.SPADE, "dig") {
     player.animate(830)
     val loc = player.tile
 
+    val progress = player.attr[Barrows.PROGRESS_ATTR] ?: 0
+    if (progress == 0 && player.attr[Barrows.TUNNEL_ATTR] == null) {
+        player.attr[Barrows.TUNNEL_ATTR] = world.random(Barrows.BROTHERS.indices)
+    }
+
     // 1) Barrows-logica: 1 loop, in plaats van twee
     Barrows.BROTHERS.forEachIndexed { index, brother ->
         if (loc.isWithinRadius(brother.mound, 4)) {


### PR DESCRIPTION
## Summary
- randomise Barrows tunnel for each player by storing index in a new attribute
- reset tunnel attribute after chest loot
- update sarcophagus logic to use per-player tunnel selection
- set tunnel index when digging with a spade

## Testing
- `gradle test` *(fails: Could not find suitable JDK for toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68507041b09083298f184a5b10ede8c3