### PR TITLE
Fix XP reward confirm button

### DIFF
--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/commands/commands/developer/randomevent.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/commands/commands/developer/randomevent.plugin.kts
@@ -1,0 +1,27 @@
+package org.alter.plugins.content.commands.commands.developer
+
+import org.alter.game.model.priv.Privilege
+import org.alter.api.cfg.Npcs
+import org.alter.plugins.content.commands.Commands_plugin.Command.tryWithUsage
+import org.alter.plugins.content.mechanics.random_events.spawnRandomEvent
+
+on_command("randomevent", Privilege.DEV_POWER, description = "Spawn a random event") {
+    val args = player.getCommandArgs()
+    if (args.isEmpty()) {
+        spawnRandomEvent(player)
+    } else {
+        val name = args.joinToString(" ").lowercase()
+        val npcId = when (name) {
+            "genie" -> Npcs.GENIE
+            "gravedigger", "leo" -> Npcs.LEO
+            "freaky forester", "forester" -> Npcs.FREAKY_FORESTER_6748
+            "sandwich lady", "sandwich" -> Npcs.SANDWICH_LADY
+            else -> -1
+        }
+        if (npcId == -1) {
+            player.message("Unknown event: $name")
+        } else {
+            spawnRandomEvent(player, npcId)
+        }
+    }
+}

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/xpreward/XpReward.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/xpreward/XpReward.kt
@@ -13,8 +13,11 @@ import org.alter.game.model.attr.XP_REWARD_SKILL
 
 object XpReward {
     const val INTERFACE_ID = 240
-    const val CONFIRM_TEXT = 26
-    const val CONFIRM_BUTTON = 27
+    /**
+     * The component used as the "Confirm" button. The widget only contains
+     * text, so we treat the label itself as the clickable component.
+     */
+    const val CONFIRM_COMPONENT = 26
 
     /**
      * Mapping of interface component ids to the skill they represent.
@@ -54,16 +57,15 @@ object XpReward {
         p.setInterfaceUnderlay(-1, -1)
         p.openInterface(INTERFACE_ID, InterfaceDestination.MAIN_SCREEN)
         p.setComponentText(INTERFACE_ID, 0, "Choose the stat you wish to be advanced!")
-        p.setComponentText(INTERFACE_ID, CONFIRM_TEXT, "Confirm")
+        p.setComponentText(INTERFACE_ID, CONFIRM_COMPONENT, "Confirm")
         // Initialize client-side script to handle button interactions and highlighting
         val containerHash = (INTERFACE_ID shl 16) or 1
-        val confirmHash = (INTERFACE_ID shl 16) or CONFIRM_TEXT
+        val confirmHash = (INTERFACE_ID shl 16) or CONFIRM_COMPONENT
         p.runClientScript(3806, -1, containerHash, confirmHash)
         COMPONENT_TO_SKILL.keys.forEach { comp ->
             p.setInterfaceEvents(INTERFACE_ID, comp, 1..1, InterfaceEvent.ClickOp1)
         }
         p.setInterfaceEvents(INTERFACE_ID, 1, 1..1, InterfaceEvent.ClickOp1)
-        p.setInterfaceEvents(INTERFACE_ID, CONFIRM_BUTTON, 1..1, InterfaceEvent.ClickOp1)
-        p.setInterfaceEvents(INTERFACE_ID, CONFIRM_TEXT, 1..1, InterfaceEvent.ClickOp1)
+        p.setInterfaceEvents(INTERFACE_ID, CONFIRM_COMPONENT, 1..1, InterfaceEvent.ClickOp1)
     }
 }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/xpreward/XpReward.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/xpreward/XpReward.kt
@@ -1,0 +1,69 @@
+package org.alter.plugins.content.interfaces.xpreward
+
+import org.alter.api.InterfaceDestination
+import org.alter.api.Skills
+import org.alter.api.ext.InterfaceEvent
+import org.alter.api.ext.openInterface
+import org.alter.api.ext.setInterfaceEvents
+import org.alter.api.ext.setInterfaceUnderlay
+import org.alter.api.ext.runClientScript
+import org.alter.game.model.entity.Player
+import org.alter.game.model.attr.XP_REWARD_ITEM
+import org.alter.game.model.attr.XP_REWARD_SKILL
+
+object XpReward {
+    const val INTERFACE_ID = 240
+    const val CONFIRM_TEXT = 26
+    const val CONFIRM_BUTTON = 27
+
+    /**
+     * Mapping of interface component ids to the skill they represent.
+     * Annotated with [JvmField] so scripts can access the map directly
+     * without going through the generated getter.
+     */
+    @JvmField
+    val COMPONENT_TO_SKILL = mapOf(
+        2 to Skills.ATTACK,
+        3 to Skills.STRENGTH,
+        4 to Skills.RANGED,
+        5 to Skills.MAGIC,
+        6 to Skills.DEFENCE,
+        7 to Skills.HITPOINTS,
+        8 to Skills.PRAYER,
+        9 to Skills.AGILITY,
+        10 to Skills.HERBLORE,
+        11 to Skills.THIEVING,
+        12 to Skills.CRAFTING,
+        13 to Skills.RUNECRAFTING,
+        14 to Skills.SLAYER,
+        15 to Skills.FARMING,
+        16 to Skills.MINING,
+        17 to Skills.SMITHING,
+        18 to Skills.FISHING,
+        19 to Skills.COOKING,
+        20 to Skills.FIREMAKING,
+        21 to Skills.WOODCUTTING,
+        22 to Skills.FLETCHING,
+        23 to Skills.CONSTRUCTION,
+        24 to Skills.HUNTER
+    )
+
+    fun open(p: Player, item: Int) {
+        p.attr[XP_REWARD_ITEM] = item
+        p.attr[XP_REWARD_SKILL] = -1
+        p.setInterfaceUnderlay(-1, -1)
+        p.openInterface(INTERFACE_ID, InterfaceDestination.MAIN_SCREEN)
+        p.setComponentText(INTERFACE_ID, 0, "Choose the stat you wish to be advanced!")
+        p.setComponentText(INTERFACE_ID, CONFIRM_TEXT, "Confirm")
+        // Initialize client-side script to handle button interactions and highlighting
+        val containerHash = (INTERFACE_ID shl 16) or 1
+        val confirmHash = (INTERFACE_ID shl 16) or CONFIRM_TEXT
+        p.runClientScript(3806, -1, containerHash, confirmHash)
+        COMPONENT_TO_SKILL.keys.forEach { comp ->
+            p.setInterfaceEvents(INTERFACE_ID, comp, 1..1, InterfaceEvent.ClickOp1)
+        }
+        p.setInterfaceEvents(INTERFACE_ID, 1, 1..1, InterfaceEvent.ClickOp1)
+        p.setInterfaceEvents(INTERFACE_ID, CONFIRM_BUTTON, 1..1, InterfaceEvent.ClickOp1)
+        p.setInterfaceEvents(INTERFACE_ID, CONFIRM_TEXT, 1..1, InterfaceEvent.ClickOp1)
+    }
+}

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/xpreward/xpreward.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/xpreward/xpreward.plugin.kts
@@ -1,0 +1,38 @@
+package org.alter.plugins.content.interfaces.xpreward
+import org.alter.game.model.attr.XP_REWARD_ITEM
+import org.alter.game.model.attr.XP_REWARD_SKILL
+import org.alter.api.ext.message
+import org.alter.api.ext.closeInterface
+import org.alter.api.ext.playSound
+import org.alter.api.cfg.Sound
+
+XpReward.COMPONENT_TO_SKILL.forEach { (component, skill) ->
+    on_button(interfaceId = XpReward.INTERFACE_ID, component = component) {
+        player.attr[XP_REWARD_SKILL] = skill
+        player.playSound(Sound.INTERFACE_SELECT1)
+    }
+}
+
+on_button(interfaceId = XpReward.INTERFACE_ID, component = 1) {
+    player.closeInterface(XpReward.INTERFACE_ID)
+}
+
+arrayOf(XpReward.CONFIRM_BUTTON, XpReward.CONFIRM_TEXT).forEach { confirm ->
+    on_button(interfaceId = XpReward.INTERFACE_ID, component = confirm) {
+        val item = player.attr[XP_REWARD_ITEM] ?: return@on_button
+        val skill = player.attr[XP_REWARD_SKILL]
+        if (skill == null || skill == -1) {
+            player.message("You need to choose which skill you wish to be advanced.")
+            return@on_button
+        }
+        player.addXp(skill, 150.0)
+        player.inventory.remove(item)
+        player.message("You feel more experienced.")
+        player.closeInterface(XpReward.INTERFACE_ID)
+    }
+}
+
+on_interface_close(XpReward.INTERFACE_ID) {
+    player.attr.remove(XP_REWARD_ITEM)
+    player.attr.remove(XP_REWARD_SKILL)
+}

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/xpreward/xpreward.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/xpreward/xpreward.plugin.kts
@@ -17,8 +17,7 @@ on_button(interfaceId = XpReward.INTERFACE_ID, component = 1) {
     player.closeInterface(XpReward.INTERFACE_ID)
 }
 
-arrayOf(XpReward.CONFIRM_BUTTON, XpReward.CONFIRM_TEXT).forEach { confirm ->
-    on_button(interfaceId = XpReward.INTERFACE_ID, component = confirm) {
+on_button(interfaceId = XpReward.INTERFACE_ID, component = XpReward.CONFIRM_COMPONENT) {
         val item = player.attr[XP_REWARD_ITEM] ?: return@on_button
         val skill = player.attr[XP_REWARD_SKILL]
         if (skill == null || skill == -1) {
@@ -29,7 +28,6 @@ arrayOf(XpReward.CONFIRM_BUTTON, XpReward.CONFIRM_TEXT).forEach { confirm ->
         player.inventory.remove(item)
         player.message("You feel more experienced.")
         player.closeInterface(XpReward.INTERFACE_ID)
-    }
 }
 
 on_interface_close(XpReward.INTERFACE_ID) {

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/mechanics/random_events/RandomEvents.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/mechanics/random_events/RandomEvents.kt
@@ -1,0 +1,33 @@
+package org.alter.plugins.content.mechanics.random_events
+
+import org.alter.api.cfg.Npcs
+import org.alter.game.fs.def.NpcDef
+import org.alter.game.model.entity.Npc
+import org.alter.game.model.entity.Player
+import org.alter.game.model.timer.TimerKey
+
+/**
+ * Utilities for random events.
+ */
+val IGNORE_EVENT_TIMER = TimerKey()
+
+private const val IGNORE_DELAY = 100
+
+private val EVENTS = intArrayOf(
+    Npcs.GENIE,
+    Npcs.LEO,
+    Npcs.FREAKY_FORESTER_6748,
+    Npcs.SANDWICH_LADY
+)
+
+fun spawnRandomEvent(player: Player, npcId: Int = EVENTS.random()) {
+    val world = player.world
+    val tile = player.tile.transform(1, 0)
+    val npc = Npc(npcId, tile, world)
+    npc.owner = player
+    npc.respawns = false
+    npc.timers[IGNORE_EVENT_TIMER] = IGNORE_DELAY
+    world.spawn(npc)
+    val name = world.definitions.get(NpcDef::class.java, npcId).name
+    player.message("A random event has appeared: $name. Talk to them or you'll be sent home!")
+}

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/mechanics/random_events/freaky_forester.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/mechanics/random_events/freaky_forester.plugin.kts
@@ -1,0 +1,30 @@
+package org.alter.plugins.content.mechanics.random_events
+
+import org.alter.api.cfg.Items
+import org.alter.api.cfg.Npcs
+import org.alter.game.model.entity.Npc
+import org.alter.game.model.queue.QueueTask
+
+private val LEDERHOSEN_REWARDS = intArrayOf(
+    Items.LEDERHOSEN_TOP,
+    Items.LEDERHOSEN_SHORTS,
+    Items.LEDERHOSEN_HAT
+)
+
+on_npc_option(npc = Npcs.FREAKY_FORESTER_6748, option = "talk-to") {
+    val eventNpc = player.getInteractingNpc()
+    if (eventNpc.owner != player) {
+        player.message("The forester doesn't seem to notice you.")
+        return@on_npc_option
+    }
+    eventNpc.timers.remove(IGNORE_EVENT_TIMER)
+    player.queue { foresterDialog(eventNpc) }
+}
+
+suspend fun QueueTask.foresterDialog(eventNpc: Npc) {
+    chatNpc("Good job hunting! Take this.", npc = eventNpc.id)
+    val reward = LEDERHOSEN_REWARDS.random()
+    player.inventory.add(reward)
+    chatNpc("Wear it with pride.", npc = eventNpc.id)
+    world.remove(eventNpc)
+}

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/mechanics/random_events/genie.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/mechanics/random_events/genie.plugin.kts
@@ -1,0 +1,24 @@
+package org.alter.plugins.content.mechanics.random_events
+
+import org.alter.api.cfg.Items
+import org.alter.api.cfg.Npcs
+import org.alter.game.model.entity.Npc
+import org.alter.game.model.queue.QueueTask
+
+on_npc_option(npc = Npcs.GENIE, option = "talk-to") {
+    val eventNpc = player.getInteractingNpc()
+    if (eventNpc.owner != player) {
+        player.message("The genie ignores you.")
+        return@on_npc_option
+    }
+    eventNpc.timers.remove(IGNORE_EVENT_TIMER)
+    player.queue { genieDialog(eventNpc) }
+}
+
+suspend fun QueueTask.genieDialog(eventNpc: Npc) {
+    chatNpc("Greetings adventurer, I have a gift for you.", npc = eventNpc.id)
+    chatPlayer("Thanks!")
+    player.inventory.add(Items.LAMP)
+    chatNpc("Rub the lamp to gain some experience.", npc = eventNpc.id)
+    world.remove(eventNpc)
+}

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/mechanics/random_events/gravedigger.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/mechanics/random_events/gravedigger.plugin.kts
@@ -1,0 +1,33 @@
+package org.alter.plugins.content.mechanics.random_events
+
+import org.alter.api.cfg.Items
+import org.alter.api.cfg.Npcs
+import org.alter.game.model.entity.Npc
+import org.alter.game.model.queue.QueueTask
+
+private val ZOMBIE_REWARDS = intArrayOf(
+    Items.ZOMBIE_SHIRT,
+    Items.ZOMBIE_TROUSERS,
+    Items.ZOMBIE_MASK,
+    Items.ZOMBIE_GLOVES,
+    Items.ZOMBIE_BOOTS
+)
+
+on_npc_option(npc = Npcs.LEO, option = "talk-to") {
+    val eventNpc = player.getInteractingNpc()
+    if (eventNpc.owner != player) {
+        player.message("Leo isn't paying attention to you.")
+        return@on_npc_option
+    }
+    eventNpc.timers.remove(IGNORE_EVENT_TIMER)
+    player.queue { gravediggerDialog(eventNpc) }
+}
+
+suspend fun QueueTask.gravediggerDialog(eventNpc: Npc) {
+    chatNpc("Thanks for helping with the graves.", npc = eventNpc.id)
+    chatPlayer("Happy to help!")
+    val reward = ZOMBIE_REWARDS.random()
+    player.inventory.add(reward)
+    chatNpc("Here, take this as a reward.", npc = eventNpc.id)
+    world.remove(eventNpc)
+}

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/mechanics/random_events/lamps.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/mechanics/random_events/lamps.plugin.kts
@@ -1,0 +1,12 @@
+package org.alter.plugins.content.mechanics.random_events
+
+import org.alter.api.cfg.Items
+import org.alter.plugins.content.interfaces.xpreward.XpReward
+
+on_item_option(item = Items.LAMP, option = "Rub") {
+    XpReward.open(player, Items.LAMP)
+}
+
+on_item_option(item = Items.BOOK_OF_KNOWLEDGE, option = "Read") {
+    XpReward.open(player, Items.BOOK_OF_KNOWLEDGE)
+}

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/mechanics/random_events/random_events.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/mechanics/random_events/random_events.plugin.kts
@@ -1,0 +1,40 @@
+package org.alter.plugins.content.mechanics.random_events
+
+import org.alter.game.model.timer.TimerKey
+import org.alter.api.cfg.Npcs
+import org.alter.plugins.content.combat.isAttacking
+import org.alter.plugins.content.combat.isBeingAttacked
+import org.alter.plugins.content.mechanics.random_events.IGNORE_EVENT_TIMER
+import org.alter.plugins.content.mechanics.random_events.spawnRandomEvent
+
+private val RANDOM_EVENT_TIMER = TimerKey()
+
+private const val MIN_DELAY = 3000
+private const val MAX_DELAY = 6000
+
+on_login {
+    player.timers[RANDOM_EVENT_TIMER] = world.random(MIN_DELAY..MAX_DELAY)
+}
+
+on_logout {
+    player.timers.remove(RANDOM_EVENT_TIMER)
+}
+
+on_timer(RANDOM_EVENT_TIMER) {
+    if (player.isAttacking() || player.isBeingAttacked()) {
+        player.timers[RANDOM_EVENT_TIMER] = world.random(MIN_DELAY..MAX_DELAY)
+        return@on_timer
+    }
+    spawnRandomEvent(player)
+    player.timers[RANDOM_EVENT_TIMER] = world.random(MIN_DELAY..MAX_DELAY)
+}
+
+on_timer(IGNORE_EVENT_TIMER) {
+    val owner = npc.owner
+    if (npc.isSpawned() && owner != null && owner.isOnline) {
+        owner.message("${npc.def.name} grows impatient and teleports you home.")
+        owner.moveTo(world.gameContext.home)
+    }
+    world.remove(npc)
+}
+

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/mechanics/random_events/sandwich_lady.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/mechanics/random_events/sandwich_lady.plugin.kts
@@ -1,0 +1,31 @@
+package org.alter.plugins.content.mechanics.random_events
+
+import org.alter.api.cfg.Items
+import org.alter.api.cfg.Npcs
+import org.alter.game.model.entity.Npc
+import org.alter.game.model.queue.QueueTask
+
+private val SANDWICH_REWARDS = intArrayOf(
+    Items.SANDWICH_LADY_HAT,
+    Items.SANDWICH_LADY_TOP,
+    Items.SANDWICH_LADY_BOTTOM,
+    Items.BAGUETTE
+)
+
+on_npc_option(npc = Npcs.SANDWICH_LADY, option = "talk-to") {
+    val eventNpc = player.getInteractingNpc()
+    if (eventNpc.owner != player) {
+        player.message("The Sandwich Lady is busy with someone else.")
+        return@on_npc_option
+    }
+    eventNpc.timers.remove(IGNORE_EVENT_TIMER)
+    player.queue { sandwichDialog(eventNpc) }
+}
+
+suspend fun QueueTask.sandwichDialog(eventNpc: Npc) {
+    chatNpc("Fancy a snack? Here you go!", npc = eventNpc.id)
+    val reward = SANDWICH_REWARDS.random()
+    player.inventory.add(reward)
+    chatNpc("Enjoy your treat.", npc = eventNpc.id)
+    world.remove(eventNpc)
+}

--- a/game-server/src/main/kotlin/org/alter/game/model/attr/Attributes.kt
+++ b/game-server/src/main/kotlin/org/alter/game/model/attr/Attributes.kt
@@ -251,3 +251,13 @@ val SLAYER_AMOUNT = AttributeKey<Int>(persistenceKey = "slayer_amount")
  * The amount of Slayer monsters left to kill
  */
 val STARTED_SLAYER = AttributeKey<Boolean>(persistenceKey = "started_slayer")
+
+/**
+ * The item id of the active XP reward interface.
+ */
+val XP_REWARD_ITEM = AttributeKey<Int>()
+
+/**
+ * The skill selected on the XP reward interface.
+ */
+val XP_REWARD_SKILL = AttributeKey<Int>()


### PR DESCRIPTION
## Summary
- adjust client script parameters when opening the XP reward interface
- treat confirm text component as the clickable button

## Testing
- `gradle test` *(fails: Cannot find a Java installation on your machine)*

------
https://chatgpt.com/codex/tasks/task_e_685078c9f03c8329a94c6ab4da863678