### PR TITLE
Fix XP reward calculation

### DIFF
--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/xpreward/XpReward.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/xpreward/XpReward.kt
@@ -11,7 +11,7 @@ object XpReward {
     private const val INTERFACE_ID = 240
     private const val VARP_ID = 261
 
-    fun open(player: Player) {
+    fun open(player: Player, item: Int? = null, xpMultiplier: Int = 10) {
         player.setInterfaceUnderlay(-1, -1)
         player.openInterface(INTERFACE_ID, InterfaceDestination.MAIN_SCREEN)
         player.setComponentText(INTERFACE_ID, 25, "Choose the stat you wish to be advanced!")
@@ -28,10 +28,14 @@ object XpReward {
             val lamp = SkillLamp.values().find { it.slot == selectedSlot } ?: return@queue
 
             val baseLevel = player.getSkills().getBaseLevel(lamp.skill)
-            val reward = 10 * baseLevel
+            val reward = xpMultiplier * baseLevel
 
             player.addXp(lamp.skill, reward.toDouble())
-            player.message("You have been rewarded $reward experience in ${lamp.name}.")
+            if (item != null) {
+                player.inventory.remove(item)
+            }
+            val skillName = Skills.getSkillName(player.world, lamp.skill)
+            player.message("You have been rewarded $reward experience in $skillName.")
             player.closeInterface(INTERFACE_ID)
         }
     }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/items/xpitems/xpitems.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/items/xpitems/xpitems.plugin.kts
@@ -1,0 +1,16 @@
+package org.alter.plugins.content.items.xpitems
+
+import org.alter.api.cfg.Items
+import org.alter.plugins.content.interfaces.xpreward.XpReward
+
+on_item_option(item = Items.LAMP, option = "Rub") {
+    XpReward.open(player, Items.LAMP, 10)
+}
+
+on_item_option(item = Items.BOOK_OF_KNOWLEDGE, option = "Read") {
+    XpReward.open(player, Items.BOOK_OF_KNOWLEDGE, 15)
+}
+
+on_item_option(item = Items.ANTIQUE_LAMP, option = "Rub") {
+    XpReward.open(player, Items.ANTIQUE_LAMP, 20)
+}


### PR DESCRIPTION
## Summary
- multiply XP reward by item-specific factor
- remove lamp/book when rewarding XP
- allow new item options to open the XP reward interface

## Testing
- `gradle test` *(fails: could not locate required JDK 17 Oracle toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_6854678d2678832989143078d6ebbf29