### PR TITLE
Add Barrows kill count tracking

### DIFF
--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/area/legacy/barrows/chest.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/area/legacy/barrows/chest.plugin.kts
@@ -2,6 +2,7 @@ package org.alter.plugins.content.area.legacy.barrows
 
 import org.alter.api.cfg.Objs
 import org.alter.api.cfg.Items
+import org.alter.api.cfg.Varp
 import org.alter.game.model.entity.Npc
 import org.alter.plugins.content.drops.DropTableFactory
 import org.alter.plugins.content.drops.DropTableType
@@ -23,6 +24,7 @@ on_obj_option(obj = Objs.CHEST_20723, option = "open") {
         }
         player.attr.remove(Barrows.LAST_BROTHER_ATTR)
         player.attr.remove(Barrows.TUNNEL_ATTR)
+        player.setVarp(Varp.BARROWS_CHEST_COUNT, player.getVarp(Varp.BARROWS_CHEST_COUNT) + 1)
         player.message("You loot the chest and feel a strange power fade.")
         return@on_obj_option
     }


### PR DESCRIPTION
## Summary
- bump barrows chest kill count varp when looting the chest

## Testing
- `gradle test --no-daemon` *(fails: Could not determine the dependencies of task ':test' due to missing Oracle JDK)*

------
https://chatgpt.com/codex/tasks/task_e_6851d2409850832987992265cd001136