### PR TITLE
Add autocast button handlers

### DIFF
--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/gameframe/tabs/combat_options/AttackTab.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/gameframe/tabs/combat_options/AttackTab.kt
@@ -2,6 +2,7 @@ package org.alter.plugins.content.interfaces.attack
 
 import org.alter.game.model.entity.Player
 import org.alter.game.model.timer.TimerKey
+import org.alter.game.model.attr.AttributeKey
 import org.alter.api.ext.getVarp
 import org.alter.api.ext.secondsToTicks
 import org.alter.api.ext.setVarp
@@ -18,6 +19,7 @@ object AttackTab {
     const val SPECIAL_ATTACK_VARP = 301
 
     val SPEC_RESTORE = TimerKey()
+    val SELECT_AUTOCAST_ATTR = AttributeKey<Boolean>()
 
     fun setEnergy(p: Player, amount: Int) {
         check(amount in 0..100)

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/gameframe/tabs/combat_options/attack_tab.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/gameframe/tabs/combat_options/attack_tab.plugin.kts
@@ -4,6 +4,7 @@ import org.alter.plugins.content.interfaces.attack.AttackTab.ATTACK_TAB_INTERFAC
 import org.alter.plugins.content.interfaces.attack.AttackTab.ATTACK_STYLE_VARP
 import org.alter.plugins.content.interfaces.attack.AttackTab.DISABLE_AUTO_RETALIATE_VARP
 import org.alter.plugins.content.interfaces.attack.AttackTab.SPECIAL_ATTACK_VARP
+import org.alter.plugins.content.interfaces.attack.AttackTab.SELECT_AUTOCAST_ATTR
 import org.alter.plugins.content.interfaces.attack.AttackTab.setEnergy
 import org.alter.api.InterfaceDestination
 import org.alter.api.cfg.Varbit
@@ -92,6 +93,7 @@ on_equip_to_slot(EquipmentType.WEAPON.id) {
  */
 on_logout {
     player.setVarp(SPECIAL_ATTACK_VARP, 0)
+    player.attr.remove(SELECT_AUTOCAST_ATTR)
 }
 
 /**
@@ -109,5 +111,6 @@ on_button(interfaceId = ATTACK_TAB_INTERFACE_ID, component = 26) {
         return@on_button
     }
     player.setVarbit(Varbit.AUTOCAST_SPELL, 0)
+    player.attr[AttackTab.SELECT_AUTOCAST_ATTR] = true
     player.openInterface(InterfaceDestination.MAGIC)
 }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/gameframe/tabs/combat_options/attack_tab.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/gameframe/tabs/combat_options/attack_tab.plugin.kts
@@ -5,6 +5,8 @@ import org.alter.plugins.content.interfaces.attack.AttackTab.ATTACK_STYLE_VARP
 import org.alter.plugins.content.interfaces.attack.AttackTab.DISABLE_AUTO_RETALIATE_VARP
 import org.alter.plugins.content.interfaces.attack.AttackTab.SPECIAL_ATTACK_VARP
 import org.alter.plugins.content.interfaces.attack.AttackTab.setEnergy
+import org.alter.api.InterfaceDestination
+import org.alter.api.cfg.Varbit
 import org.alter.game.model.attr.NEW_ACCOUNT_ATTR
 import org.alter.plugins.content.combat.specialattack.SpecialAttacks
 
@@ -90,4 +92,22 @@ on_equip_to_slot(EquipmentType.WEAPON.id) {
  */
 on_logout {
     player.setVarp(SPECIAL_ATTACK_VARP, 0)
+}
+
+/**
+ * Toggle defensive spell casting.
+ */
+on_button(interfaceId = ATTACK_TAB_INTERFACE_ID, component = 21) {
+    player.toggleVarbit(Varbit.DEFENSIVE_CASTING_MODE)
+}
+
+/**
+ * Open spellbook to select an autocast spell.
+ */
+on_button(interfaceId = ATTACK_TAB_INTERFACE_ID, component = 26) {
+    if (!player.lock.canInterfaceInteract()) {
+        return@on_button
+    }
+    player.setVarbit(Varbit.AUTOCAST_SPELL, 0)
+    player.openInterface(InterfaceDestination.MAGIC)
 }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/gameframe/tabs/combat_options/autocast.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/gameframe/tabs/combat_options/autocast.plugin.kts
@@ -1,0 +1,29 @@
+package org.alter.plugins.content.interfaces.attack
+
+import org.alter.plugins.content.interfaces.attack.AttackTab.SELECT_AUTOCAST_ATTR
+import org.alter.api.InterfaceDestination
+import org.alter.api.cfg.Varbit
+import org.alter.plugins.content.combat.strategy.magic.CombatSpell
+import org.alter.plugins.content.magic.MagicSpells
+
+/**
+ * Handles autocast spell selection.
+ */
+
+MagicSpells.getCombatSpells().forEach { (_, meta) ->
+    on_button(interfaceId = meta.interfaceId, component = meta.component) {
+        if (player.attr[SELECT_AUTOCAST_ATTR] != true) {
+            return@on_button
+        }
+        val spell = CombatSpell.values.firstOrNull { it.id == meta.paramItem } ?: return@on_button
+        player.setVarbit(Varbit.AUTOCAST_SPELL, spell.autoCastId)
+        player.attr.remove(SELECT_AUTOCAST_ATTR)
+        player.openInterface(InterfaceDestination.ATTACK)
+    }
+}
+
+on_interface_close(interfaceId = InterfaceDestination.MAGIC.interfaceId) {
+    if (player.attr.remove(SELECT_AUTOCAST_ATTR) == true) {
+        player.openInterface(InterfaceDestination.ATTACK)
+    }
+}

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/gameframe/tabs/combat_options/autocast.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/gameframe/tabs/combat_options/autocast.plugin.kts
@@ -23,7 +23,8 @@ MagicSpells.getCombatSpells().forEach { (_, meta) ->
 }
 
 on_interface_close(interfaceId = InterfaceDestination.MAGIC.interfaceId) {
-    if (player.attr.remove(SELECT_AUTOCAST_ATTR) == true) {
+    if (player.attr.has(SELECT_AUTOCAST_ATTR)) {
+        player.attr.remove(SELECT_AUTOCAST_ATTR)
         player.openInterface(InterfaceDestination.ATTACK)
     }
 }


### PR DESCRIPTION
## Summary
- add handlers for defensive and autocast buttons in combat tab

## Testing
- `gradle build` *(fails: Could not determine the dependencies of task ':compileKotlin'. Cannot find a Java installation matching vendor Oracle)*

------
https://chatgpt.com/codex/tasks/task_e_685ef6a26bdc83299225d4b76ff360e8