### PR TITLE
Set varp values when equipping specific staves

### DIFF
--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/items/ancient_staff/ancient_staff.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/items/ancient_staff/ancient_staff.plugin.kts
@@ -1,0 +1,7 @@
+on_item_equip(Items.ANCIENT_STAFF) {
+    player.setVarp(664, Items.ANCIENT_STAFF)
+}
+
+on_item_unequip(Items.ANCIENT_STAFF) {
+    player.setVarp(664, 0)
+}

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/items/staff_of_air/staff_of_air.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/items/staff_of_air/staff_of_air.plugin.kts
@@ -1,0 +1,7 @@
+on_item_equip(Items.STAFF_OF_AIR) {
+    player.setVarp(664, -1)
+}
+
+on_item_unequip(Items.STAFF_OF_AIR) {
+    player.setVarp(664, 0)
+}


### PR DESCRIPTION
## Summary
- set varp 664 to -1 when Staff of Air is equipped
- set varp 664 to Ancient Staff ID when Ancient Staff is equipped
- reset varp 664 to 0 when Staff of Air or Ancient Staff are unequipped

## Testing
- `gradle build` *(fails: org.apache.http.ssl.SSLInitializationException: Tag number over 30 is not supported)*
- `apt-get install -y ca-certificates-java` *(fails: UnableToSaveKeystoreException: /etc/ssl/certs/java/cacerts)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a1a9edec8329977b14ac84f0a620