### PR TITLE
Add AI player service for managing placeholder accounts

### DIFF
--- a/ai_players.yml
+++ b/ai_players.yml
@@ -1,0 +1,6 @@
+min_online: 0
+max_online: 10
+names:
+  - Alice
+  - Bob
+  - Charlie

--- a/game-server/src/main/kotlin/org/alter/game/service/AiPlayerConfig.kt
+++ b/game-server/src/main/kotlin/org/alter/game/service/AiPlayerConfig.kt
@@ -1,0 +1,36 @@
+package org.alter.game.service
+
+import gg.rsmod.util.ServerProperties
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.alter.game.Server
+import org.alter.game.model.World
+import java.io.File
+
+/**
+ * Service responsible for loading AI player configuration from [ai_players.yml].
+ */
+class AiPlayerConfig : Service {
+
+    var minOnline: Int = 0
+    var maxOnline: Int = 0
+    var names: List<String> = emptyList()
+
+    override fun init(server: Server, world: World, serviceProperties: ServerProperties) {
+        val file = File("../ai_players.yml")
+        val props = ServerProperties().loadYaml(file)
+        minOnline = props.getOrDefault("min_online", 0)
+        maxOnline = props.getOrDefault("max_online", 0)
+        names = props.getOrDefault("names", emptyList())
+        logger.info { "Loaded AI player config: minOnline=$minOnline, maxOnline=$maxOnline, names=${names.size}" }
+    }
+
+    override fun postLoad(server: Server, world: World) { }
+
+    override fun bindNet(server: Server, world: World) { }
+
+    override fun terminate(server: Server, world: World) { }
+
+    companion object {
+        private val logger = KotlinLogging.logger {}
+    }
+}

--- a/game-server/src/main/kotlin/org/alter/game/service/AiPlayerService.kt
+++ b/game-server/src/main/kotlin/org/alter/game/service/AiPlayerService.kt
@@ -1,0 +1,73 @@
+package org.alter.game.service
+
+import org.alter.game.Server
+import org.alter.game.model.PlayerUID
+import org.alter.game.model.World
+import org.alter.game.model.entity.Player
+import gg.rsmod.util.ServerProperties
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlin.math.min
+
+/**
+ * Service that keeps a configurable number of AI accounts online.
+ * It registers or unregisters placeholder [Player] instances on start
+ * to ensure the count remains within the configured bounds.
+ */
+class AiPlayerService : Service {
+
+    private lateinit var config: AiPlayerConfig
+    private val aiPlayers = mutableListOf<Player>()
+
+    override fun init(server: Server, world: World, serviceProperties: ServerProperties) {
+        config = world.getService(AiPlayerConfig::class.java)
+            ?: throw IllegalStateException("AiPlayerConfig service not loaded")
+    }
+
+    override fun postLoad(server: Server, world: World) {
+        maintain(world)
+    }
+
+    override fun bindNet(server: Server, world: World) { }
+
+    override fun terminate(server: Server, world: World) {
+        aiPlayers.forEach { world.unregister(it) }
+        aiPlayers.clear()
+    }
+
+    /**
+     * Ensure the amount of registered AI players is within the configured
+     * [AiPlayerConfig.minOnline] and [AiPlayerConfig.maxOnline] bounds.
+     */
+    fun maintain(world: World) {
+        if (!::config.isInitialized) return
+
+        val current = aiPlayers.size
+        if (current < config.minOnline) {
+            val available = config.names.filter { name -> aiPlayers.none { it.username.equals(name, true) } }
+            val needed = min(config.minOnline - current, available.size)
+            available.take(needed).forEach { name ->
+                val p = Player(world)
+                p.uid = PlayerUID(name)
+                p.username = name
+                p.tile = world.gameContext.home
+                world.register(p)
+                aiPlayers.add(p)
+            }
+            if (needed > 0) {
+                logger.info { "Registered $needed AI player(s)." }
+            }
+        } else if (current > config.maxOnline) {
+            val removeCount = current - config.maxOnline
+            repeat(removeCount) {
+                val p = aiPlayers.removeAt(aiPlayers.lastIndex)
+                world.unregister(p)
+            }
+            logger.info { "Unregistered $removeCount AI player(s)." }
+        }
+    }
+
+    companion object {
+        private val logger = KotlinLogging.logger {}
+    }
+}
+

--- a/game.example.yml
+++ b/game.example.yml
@@ -44,6 +44,8 @@ services:
 
   - class: org.alter.game.service.game.ObjectMetadataService
 
+  - class: org.alter.game.service.AiPlayerConfig
+
   - class: org.alter.service.DumpEntityIdService
     cache-path: "../data/cache/"
     output-path: "../game-api/src/main/kotlin/org/alter/api/cfg/"
@@ -57,3 +59,5 @@ services:
 
   - class: org.alter.plugins.service.worldlist.WorldListService
     port: 4842
+
+  - class: org.alter.game.service.AiPlayerService


### PR DESCRIPTION
## Summary
- load AI player settings from ai_players.yml via configuration service
- introduce AiPlayerService that maintains placeholder players between configured min and max counts
- register configuration and player services in example game settings

## Testing
- `gradle test` *(fails: Could not resolve net.runelite:cache:1.10.4, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ba25107883298bf0b916d43cc3f6