### PR TITLE
feat(ai): add AI player controller and build config

### DIFF
--- a/ai_builds.yml
+++ b/ai_builds.yml
@@ -1,0 +1,56 @@
+---
+starter:
+  goals:
+    - skill: attack
+      target: 5
+      npc: 1
+      spawn:
+        x: 3222
+        z: 3218
+        height: 0
+    - skill: woodcutting
+      target: 10
+      obj: 1276
+      spawn:
+        x: 3220
+        z: 3224
+        height: 0
+fighter:
+  goals:
+    - skill: attack
+      target: 20
+      npc: 15
+      spawn:
+        x: 3203
+        z: 3231
+        height: 0
+    - skill: strength
+      target: 20
+      npc: 15
+      spawn:
+        x: 3203
+        z: 3231
+        height: 0
+    - skill: defence
+      target: 20
+      npc: 15
+      spawn:
+        x: 3203
+        z: 3231
+        height: 0
+skiller:
+  goals:
+    - skill: woodcutting
+      target: 30
+      obj: 1277
+      spawn:
+        x: 3185
+        z: 3225
+        height: 0
+    - skill: fishing
+      target: 30
+      obj: 1009
+      spawn:
+        x: 3244
+        z: 3152
+        height: 0

--- a/game-plugins/src/main/kotlin/org/alter/plugins/ai/AiPlayerController.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/ai/AiPlayerController.kt
@@ -1,0 +1,106 @@
+package org.alter.plugins.ai
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.alter.api.ext.player
+import org.alter.game.model.Tile
+import org.alter.game.model.World
+import org.alter.game.model.entity.Player
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.ArrayDeque
+
+/**
+ * Simple state driven controller for automated players.
+ *
+ * Loads training goals from [ai_builds.yml] and NPC definitions from
+ * [data/cfg/npcs.csv] to determine how to navigate and act in the world.
+ */
+class AiPlayerController(
+    private val world: World,
+    private val player: Player,
+    buildName: String
+) {
+
+    private val npcConfigs: Map<Int, String> = loadNpcConfigs()
+    private val builds: Map<String, Build> = loadBuilds()
+    private val goalQueue: ArrayDeque<TrainingGoal> =
+        ArrayDeque(builds[buildName]?.goals ?: emptyList())
+
+    private var state: State = State.IDLE
+
+    fun tick() {
+        when (val s = state) {
+            State.IDLE -> {
+                val next = goalQueue.removeFirstOrNull() ?: return
+                state = State.MOVING(next)
+                player.queue {
+                    val pawn = this.player
+                    pawn.walkTo(this, next.spawn.toTile())
+                }
+            }
+            is State.MOVING -> {
+                if (player.tile == s.goal.spawn.toTile()) {
+                    state = State.ACTING(s.goal)
+                    actOnGoal(s.goal)
+                }
+            }
+            is State.ACTING -> state = State.IDLE
+        }
+    }
+
+    private fun actOnGoal(goal: TrainingGoal) {
+        goal.npc?.let { npcId ->
+            val npc = world.npcs.firstOrNull { it.id == npcId && it.tile == goal.spawn.toTile() }
+            if (npc != null) {
+                player.attack(npc)
+            }
+        }
+    }
+
+    private fun loadNpcConfigs(): Map<Int, String> {
+        val path = Paths.get("data/cfg/npcs.csv")
+        if (!Files.exists(path)) return emptyMap()
+        return Files.newBufferedReader(path).use { reader ->
+            reader.lineSequence()
+                .mapNotNull { line ->
+                    val parts = line.split(",", limit = 2)
+                    val id = parts.firstOrNull()?.toIntOrNull() ?: return@mapNotNull null
+                    val desc = parts.getOrNull(1)?.trim() ?: ""
+                    id to desc
+                }.toMap()
+        }
+    }
+
+    private fun loadBuilds(): Map<String, Build> {
+        val path = Paths.get("ai_builds.yml")
+        if (!Files.exists(path)) return emptyMap()
+        val mapper = ObjectMapper(YAMLFactory())
+            .registerKotlinModule()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        return mapper.readValue(path.toFile())
+    }
+
+    data class Build(val goals: List<TrainingGoal> = emptyList())
+    data class TrainingGoal(
+        val skill: String,
+        val target: Int,
+        val npc: Int? = null,
+        val obj: Int? = null,
+        val spawn: Spawn
+    )
+
+    data class Spawn(val x: Int, val z: Int, val height: Int = 0) {
+        fun toTile(): Tile = Tile(x, z, height)
+    }
+
+    private sealed class State {
+        object IDLE : State()
+        data class MOVING(val goal: TrainingGoal) : State()
+        data class ACTING(val goal: TrainingGoal) : State()
+    }
+}
+


### PR DESCRIPTION
## Summary
- add AI player controller with simple state machine
- load training goals from YAML and NPC data from CSV
- move AI build config to project root and expand example builds

## Testing
- `gradle :game-plugins:compileKotlin` *(fails: Cannot find a Java installation matching {languageVersion=17})*

------
https://chatgpt.com/codex/tasks/task_e_68b6ba3cca308329afb7bf4ab3798677