### PR TITLE
Add jackson module kotlin dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,7 @@ allprojects {
         implementation(lib.jackson.dataformat.yaml)
         implementation(lib.jackson.dataformat.toml)
         implementation(lib.jackson.databind)
+        implementation(lib.jackson.module.kotlin)
         implementation(lib.json)
         implementation(lib.jbcrypt)
         implementation(lib.gson)


### PR DESCRIPTION
## Summary
- include Jackson Kotlin module in shared dependencies

## Testing
- `gradle test` *(fails: Could not resolve dependencies due to SSL initialization issues)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f43e67488329aee7006d759c11da