### PR TITLE
Add safe deque removal helper for AI controller

### DIFF
--- a/game-plugins/src/main/kotlin/org/alter/plugins/ai/AiPlayerController.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/ai/AiPlayerController.kt
@@ -14,6 +14,11 @@ import java.nio.file.Paths
 import java.util.ArrayDeque
 
 /**
+ * Returns and removes the first element of this [ArrayDeque], or `null` if the deque is empty.
+ */
+private fun <T> ArrayDeque<T>.removeFirstOrNull(): T? = if (isEmpty()) null else removeFirst()
+
+/**
  * Simple state driven controller for automated players.
  *
  * Loads training goals from [ai_builds.yml] and NPC definitions from


### PR DESCRIPTION
## Summary
- add ArrayDeque.removeFirstOrNull helper
- use helper in AI player controller to avoid unresolved reference

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 PATH=/usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH gradle :game-plugins:test` *(fails: Could not resolve net.runelite:cache:1.10.4 - 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b6fb11b6a48329864fd0d5207475f0