### PR TITLE
Hook AI players into learning service with goal-driven controller

### DIFF
--- a/game-plugins/src/main/kotlin/org/alter/plugins/ai/AiPlayerController.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/ai/AiPlayerController.kt
@@ -9,14 +9,10 @@ import org.alter.api.ext.player
 import org.alter.game.model.Tile
 import org.alter.game.model.World
 import org.alter.game.model.entity.Player
+import org.alter.game.service.ai.AiLearningService
 import java.nio.file.Files
 import java.nio.file.Paths
-import java.util.ArrayDeque
-
-/**
- * Returns and removes the first element of this [ArrayDeque], or `null` if the deque is empty.
- */
-private fun <T> ArrayDeque<T>.removeFirstOrNull(): T? = if (isEmpty()) null else removeFirst()
+import kotlin.random.Random
 
 /**
  * Simple state driven controller for automated players.
@@ -27,20 +23,20 @@ private fun <T> ArrayDeque<T>.removeFirstOrNull(): T? = if (isEmpty()) null else
 class AiPlayerController(
     private val world: World,
     private val player: Player,
+    private val learning: AiLearningService,
     buildName: String
 ) {
 
     private val npcConfigs: Map<Int, String> = loadNpcConfigs()
     private val builds: Map<String, Build> = loadBuilds()
-    private val goalQueue: ArrayDeque<TrainingGoal> =
-        ArrayDeque(builds[buildName]?.goals ?: emptyList())
+    private val goals: List<TrainingGoal> = builds[buildName]?.goals ?: emptyList()
 
     private var state: State = State.IDLE
 
     fun tick() {
         when (val s = state) {
             State.IDLE -> {
-                val next = goalQueue.removeFirstOrNull() ?: return
+                val next = chooseNextGoal() ?: return
                 state = State.MOVING(next)
                 player.queue {
                     val pawn = this.player
@@ -53,7 +49,10 @@ class AiPlayerController(
                     actOnGoal(s.goal)
                 }
             }
-            is State.ACTING -> state = State.IDLE
+            is State.ACTING -> {
+                learning.logGoalEvent(player, s.goal.skill, 1.0)
+                state = State.IDLE
+            }
         }
     }
 
@@ -87,6 +86,16 @@ class AiPlayerController(
             .registerKotlinModule()
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
         return mapper.readValue(path.toFile())
+    }
+
+    private fun chooseNextGoal(): TrainingGoal? {
+        if (goals.isEmpty()) return null
+        val epsilon = 0.1
+        return if (Random.nextDouble() < epsilon) {
+            goals.random()
+        } else {
+            goals.maxByOrNull { learning.getGoalValue(it.skill) } ?: goals.random()
+        }
     }
 
     data class Build(val goals: List<TrainingGoal> = emptyList())

--- a/game-server/src/main/kotlin/org/alter/game/service/AiPlayerService.kt
+++ b/game-server/src/main/kotlin/org/alter/game/service/AiPlayerService.kt
@@ -4,6 +4,7 @@ import org.alter.game.Server
 import org.alter.game.model.PlayerUID
 import org.alter.game.model.World
 import org.alter.game.model.entity.Player
+import org.alter.game.service.ai.AiLearningService
 import gg.rsmod.util.ServerProperties
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlin.math.min
@@ -17,10 +18,12 @@ class AiPlayerService : Service {
 
     private lateinit var config: AiPlayerConfig
     private val aiPlayers = mutableListOf<Player>()
+    private var learning: AiLearningService? = null
 
     override fun init(server: Server, world: World, serviceProperties: ServerProperties) {
         config = world.getService(AiPlayerConfig::class.java)
             ?: throw IllegalStateException("AiPlayerConfig service not loaded")
+        learning = world.getService(AiLearningService::class.java)
     }
 
     override fun postLoad(server: Server, world: World) {
@@ -30,7 +33,10 @@ class AiPlayerService : Service {
     override fun bindNet(server: Server, world: World) { }
 
     override fun terminate(server: Server, world: World) {
-        aiPlayers.forEach { world.unregister(it) }
+        aiPlayers.forEach {
+            learning?.unregisterAiPlayer(it)
+            world.unregister(it)
+        }
         aiPlayers.clear()
     }
 
@@ -52,6 +58,7 @@ class AiPlayerService : Service {
                 p.tile = world.gameContext.home
                 world.register(p)
                 aiPlayers.add(p)
+                learning?.registerAiPlayer(p)
             }
             if (needed > 0) {
                 logger.info { "Registered $needed AI player(s)." }
@@ -60,6 +67,7 @@ class AiPlayerService : Service {
             val removeCount = current - config.maxOnline
             repeat(removeCount) {
                 val p = aiPlayers.removeAt(aiPlayers.lastIndex)
+                learning?.unregisterAiPlayer(p)
                 world.unregister(p)
             }
             logger.info { "Unregistered $removeCount AI player(s)." }

--- a/game-server/src/main/kotlin/org/alter/game/service/ai/AiLearningService.kt
+++ b/game-server/src/main/kotlin/org/alter/game/service/ai/AiLearningService.kt
@@ -104,6 +104,24 @@ class AiLearningService : Service {
     }
 
     /**
+     * Log a generic goal completion for an AI player.
+     */
+    fun logGoalEvent(player: Player, goal: String, reward: Double) {
+        if (player !in aiPlayers) return
+        val line = "goal,${player.username},$goal,$reward,${System.currentTimeMillis()}\n"
+        try {
+            Files.write(eventLog, line.toByteArray(), StandardOpenOption.CREATE, StandardOpenOption.APPEND)
+        } catch (e: IOException) {
+            System.err.println("AiLearningService failed to log goal event: ${e.message}")
+        }
+    }
+
+    /**
+     * Retrieve the current Q-value for a goal state.
+     */
+    fun getGoalValue(goal: String): Double = qTable.getOrDefault("goal|$goal", 0.0)
+
+    /**
      * Reads the event log and updates the in memory Q-table. After processing
      * the log file is cleared to avoid duplicate processing.
      */


### PR DESCRIPTION
## Summary
- Register and unregister AI players with AiLearningService so their actions are tracked
- Add goal logging and Q-table access in AiLearningService
- Drive AI player goals via epsilon-greedy selection using Q-table rewards

## Testing
- `gradle test` *(fails: Could not resolve dependency net.runelite:cache due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b71fa85f3c8329bf1b39d87e63ecbd