### PR TITLE
Add AI player controller service

### DIFF
--- a/game-plugins/src/main/kotlin/org/alter/plugins/ai/AiPlayerController.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/ai/AiPlayerController.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.alter.api.ext.player
 import org.alter.game.model.Tile
 import org.alter.game.model.World
@@ -32,11 +33,13 @@ class AiPlayerController(
     private val goals: List<TrainingGoal> = builds[buildName]?.goals ?: emptyList()
 
     private var state: State = State.IDLE
+    private val logger = KotlinLogging.logger {}
 
     fun tick() {
         when (val s = state) {
             State.IDLE -> {
                 val next = chooseNextGoal() ?: return
+                logger.info { "${player.username} selected goal ${next.skill} at (${next.spawn.x}, ${next.spawn.z})" }
                 state = State.MOVING(next)
                 player.queue {
                     val pawn = this.player
@@ -51,6 +54,7 @@ class AiPlayerController(
             }
             is State.ACTING -> {
                 learning.logGoalEvent(player, s.goal.skill, 1.0)
+                logger.info { "${player.username} completed goal ${s.goal.skill}" }
                 state = State.IDLE
             }
         }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/service/ai/AiPlayerControllerService.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/service/ai/AiPlayerControllerService.kt
@@ -1,0 +1,43 @@
+package org.alter.plugins.service.ai
+
+import org.alter.game.Server
+import org.alter.game.model.World
+import org.alter.game.service.Service
+import org.alter.game.service.AiPlayerService
+import org.alter.game.service.ai.AiLearningService
+import org.alter.plugins.ai.AiPlayerController
+import gg.rsmod.util.ServerProperties
+
+class AiPlayerControllerService : Service {
+
+    private val controllers = mutableListOf<AiPlayerController>()
+    private var build: String = "starter"
+
+    override fun init(server: Server, world: World, serviceProperties: ServerProperties) {
+        build = serviceProperties.getOrDefault("build", build)
+    }
+
+    override fun postLoad(server: Server, world: World) {
+        val aiService = world.getService(AiPlayerService::class.java) ?: return
+        val learning = world.getService(AiLearningService::class.java) ?: return
+
+        aiService.maintain(world)
+        aiService.getPlayers().forEach { player ->
+            learning.registerAiPlayer(player)
+            controllers.add(AiPlayerController(world, player, learning, build))
+        }
+
+        world.queue {
+            while (true) {
+                controllers.forEach { it.tick() }
+                wait(1)
+            }
+        }
+    }
+
+    override fun bindNet(server: Server, world: World) { }
+
+    override fun terminate(server: Server, world: World) {
+        controllers.clear()
+    }
+}

--- a/game-server/src/main/kotlin/org/alter/game/service/AiPlayerService.kt
+++ b/game-server/src/main/kotlin/org/alter/game/service/AiPlayerService.kt
@@ -67,6 +67,8 @@ class AiPlayerService : Service {
         }
     }
 
+    fun getPlayers(): List<Player> = aiPlayers.toList()
+
     companion object {
         private val logger = KotlinLogging.logger {}
     }

--- a/game.example.yml
+++ b/game.example.yml
@@ -60,5 +60,10 @@ services:
   - class: org.alter.plugins.service.worldlist.WorldListService
     port: 4842
 
+  - class: org.alter.game.service.ai.AiLearningService
+
   - class: org.alter.game.service.AiPlayerService
+
+  - class: org.alter.plugins.service.ai.AiPlayerControllerService
+    build: starter
 


### PR DESCRIPTION
## Summary
- expose AI player list for controller integration
- add AI controller service to tick bots and log goals
- enable AI learning and controller services in config

## Testing
- `gradle test` *(fails: Could not resolve net.runelite:cache:1.10.4)*

------
https://chatgpt.com/codex/tasks/task_e_68b7242190dc83298ae2844d8d06a733