### PR TITLE
Align AI spawn tiles with target positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Due to the plugin capabilities, even owners without programming experience can j
 * [Z-Kris's Event Inspector](https://media.z-kris.com/runelite-event-inspector-client.jar) , Want to dump osrs data easily? or see hows what being sent? Use this RL Client it's pretty easy to use.
 * That's it for now. If you got something to share feel free to ping me on discord ill inspect it and add it.
 
+### AI builds
+* Training goals for automated players are defined in `ai_builds.yml`.
+* Each goal's `spawn` block points to the exact tile where the target NPC or object is expected.
+
 ### Credits:
 * Credits are given out to everyone who helped out with information or contributed in some form to the project. And can be found in: [Here](https://github.com/AlterRSPS)
 

--- a/ai_builds.yml
+++ b/ai_builds.yml
@@ -4,28 +4,28 @@ starter:
     - skill: attack
       target: 20
       npc: 2858
-      spawn:
-        x: 2966
-        z: 3371
+      spawn: # exact tile where the target is expected
+        x: 2968
+        z: 3372
         height: 0
     - skill: strength
       target: 20
       npc: 2858
-      spawn:
-        x: 2966
-        z: 3371
+      spawn: # exact tile where the target is expected
+        x: 2968
+        z: 3372
         height: 0
     - skill: defence
       target: 20
       npc: 2858
-      spawn:
-        x: 2966
-        z: 3371
+      spawn: # exact tile where the target is expected
+        x: 2968
+        z: 3372
         height: 0
     - skill: woodcutting
       target: 10
       obj: 1276
-      spawn:
+      spawn: # exact tile where the target is expected
         x: 3000
         z: 3363
         height: 0
@@ -34,21 +34,21 @@ fighter:
     - skill: attack
       target: 40
       npc: 3269
-      spawn:
-        x: 2965
-        z: 3392
+      spawn: # exact tile where the target is expected
+        x: 2967
+        z: 3394
         height: 0
     - skill: strength
       target: 50
       npc: 3269
-      spawn:
-        x: 2965
-        z: 3292
+      spawn: # exact tile where the target is expected
+        x: 2967
+        z: 3394
         height: 0
     - skill: defence
       target: 40
       npc: 3269
-      spawn:
-        x: 2965
-        z: 3292
+      spawn: # exact tile where the target is expected
+        x: 2967
+        z: 3394
         height: 0

--- a/game-plugins/src/main/kotlin/org/alter/plugins/ai/AiPlayerController.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/ai/AiPlayerController.kt
@@ -104,9 +104,11 @@ class AiPlayerController(
         val target: Int,
         val npc: Int? = null,
         val obj: Int? = null,
+        /** Exact tile where the target NPC or object is expected. */
         val spawn: Spawn
     )
 
+    /** Coordinates for the exact tile the goal uses. */
     data class Spawn(val x: Int, val z: Int, val height: Int = 0) {
         fun toTile(): Tile = Tile(x, z, height)
     }


### PR DESCRIPTION
## Summary
- Correct spawn coordinates in `ai_builds.yml` to match in-game NPC locations and annotate each spawn as the exact target tile
- Document exact spawn tile usage for AI goals
- Describe AI build spawn blocks in README

## Testing
- `gradle test` *(fails: Could not resolve net.runelite:cache:1.10.4 - 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b72423762c83298c5b387ef95d1ca5