### PR TITLE
Enable AI player controllers and periodic ticks

### DIFF
--- a/game-server/src/main/kotlin/org/alter/game/service/AiPlayerService.kt
+++ b/game-server/src/main/kotlin/org/alter/game/service/AiPlayerService.kt
@@ -4,9 +4,13 @@ import org.alter.game.Server
 import org.alter.game.model.PlayerUID
 import org.alter.game.model.World
 import org.alter.game.model.entity.Player
+import org.alter.game.service.GameService
+import org.alter.game.service.ai.AiLearningService
 import gg.rsmod.util.ServerProperties
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlin.math.min
+import java.lang.reflect.Constructor
+import java.lang.reflect.Method
 
 /**
  * Service that keeps a configurable number of AI accounts online.
@@ -17,22 +21,40 @@ class AiPlayerService : Service {
 
     private lateinit var config: AiPlayerConfig
     private val aiPlayers = mutableListOf<Player>()
+    private lateinit var learning: AiLearningService
+    private var controllerCtor: Constructor<*>? = null
+    private var tickMethod: Method? = null
+    private val controllers = mutableMapOf<Player, Any>()
 
     override fun init(server: Server, world: World, serviceProperties: ServerProperties) {
         config = world.getService(AiPlayerConfig::class.java) ?: AiPlayerConfig().also {
             it.init(server, world, ServerProperties())
         }
+        learning = world.getService(AiLearningService::class.java) ?: AiLearningService()
+        try {
+            val clazz = Class.forName("org.alter.plugins.ai.AiPlayerController")
+            controllerCtor = clazz.getConstructor(World::class.java, Player::class.java, AiLearningService::class.java, String::class.java)
+            tickMethod = clazz.getMethod("tick")
+        } catch (e: Exception) {
+            logger.warn { "AiPlayerController not found; AI players will be idle." }
+        }
     }
 
     override fun postLoad(server: Server, world: World) {
         maintain(world)
+        scheduleTick(world)
     }
 
     override fun bindNet(server: Server, world: World) { }
 
     override fun terminate(server: Server, world: World) {
-        aiPlayers.forEach { world.unregister(it) }
+        aiPlayers.forEach {
+            controllers.remove(it)
+            learning.unregisterAiPlayer(it)
+            world.unregister(it)
+        }
         aiPlayers.clear()
+        controllers.clear()
     }
 
     /**
@@ -53,6 +75,11 @@ class AiPlayerService : Service {
                 p.tile = world.gameContext.home
                 world.register(p)
                 aiPlayers.add(p)
+                learning.registerAiPlayer(p)
+                controllerCtor?.let { ctor ->
+                    runCatching { controllers[p] = ctor.newInstance(world, p, learning, "starter") }
+                        .onFailure { e -> logger.error(e) { "Failed to create AI controller for ${'$'}name" } }
+                }
             }
             if (needed > 0) {
                 logger.info { "Registered $needed AI player(s)." }
@@ -61,9 +88,27 @@ class AiPlayerService : Service {
             val removeCount = current - config.maxOnline
             repeat(removeCount) {
                 val p = aiPlayers.removeAt(aiPlayers.lastIndex)
+                controllers.remove(p)
+                learning.unregisterAiPlayer(p)
                 world.unregister(p)
             }
             logger.info { "Unregistered $removeCount AI player(s)." }
+        }
+    }
+
+    private fun scheduleTick(world: World) {
+        val game = world.getService(GameService::class.java) ?: return
+        game.submitGameThreadJob {
+            tickControllers()
+            scheduleTick(world)
+        }
+    }
+
+    private fun tickControllers() {
+        val method = tickMethod ?: return
+        controllers.values.forEach { ctrl ->
+            runCatching { method.invoke(ctrl) }
+                .onFailure { e -> logger.error(e) { "Error ticking AI controller" } }
         }
     }
 


### PR DESCRIPTION
## Summary
- reflectively load `AiPlayerController` for each AI bot
- register/unregister AI bots with `AiLearningService`
- schedule a repeating game-thread job to tick AI controllers

## Testing
- `gradle test` *(fails: Could not determine the dependencies of task ':test'... Cannot find a Java installation matching: {languageVersion=17} )*


------
https://chatgpt.com/codex/tasks/task_e_68b7274da8188329828493be7c98420d