### PR TITLE
Add nothing entries to NPC drop tables

### DIFF
--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/animals/gorak_lvl145.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/animals/gorak_lvl145.plugin.kts
@@ -17,6 +17,7 @@ val droptable =
             total(128)
             obj(Items.GORAK_CLAWS, quantity = 1, 1)
             obj(Items.RING_OF_LIFE, quantity = 1, 1)
+            nothing(126)
         }
         table("herbs") {
             total(128)
@@ -26,6 +27,7 @@ val droptable =
             obj(Items.GRIMY_HARRALANDER, quantityRange = 1..3, 25)
             obj(Items.GRIMY_RANARR_WEED, quantityRange = 1..3, 25)
             obj(Items.GRIMY_IRIT_LEAF, quantityRange = 1..3, 25)
+            nothing(1)
         }
         table("second") {
             total(128)
@@ -33,10 +35,12 @@ val droptable =
             obj(Items.GRIMY_KWUARM, quantityRange = 1..3, 25)
             obj(Items.GRIMY_CADANTINE, quantityRange = 1..3, 25)
             obj(Items.GRIMY_DWARF_WEED, quantityRange = 1..3, 25)
+            nothing(28)
         }
         table("coins") {
             total(128)
             obj(Items.COINS, quantityRange = 100..2215, 15)
+            nothing(113)
         }
 
         }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/animals/king_scorpion_lvl32.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/animals/king_scorpion_lvl32.plugin.kts
@@ -17,6 +17,7 @@ val droptable =
             total(128)
             obj(Items.IRON_ORE, quantity = 1, 5)
             obj(Items.COAL, quantity = 1, 5)
+            nothing(118)
         }
         }
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/critters/brine_rat_lvl70.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/critters/brine_rat_lvl70.plugin.kts
@@ -18,6 +18,7 @@ val droptable =
             obj(Items.CHAOS_RUNE, quantityRange = 1..5, 9)
             obj(Items.DEATH_RUNE, quantityRange = 1..4, 9)
             obj(Items.BLOOD_RUNE, quantityRange = 1..4, 9)
+            nothing(101)
         }
     }
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/critters/cave_crawler_lvl23.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/critters/cave_crawler_lvl23.plugin.kts
@@ -14,6 +14,7 @@ val droptable =
             obj(Items.BRONZE_BOOTS, quantity = 1)
             obj(Items.NATURE_RUNE, quantityRange = 5..7)
             obj(Items.FIRE_RUNE, quantityRange = 15..20)
+            nothing(125)
         }
         table("herbs") {
             total(128)
@@ -23,6 +24,7 @@ val droptable =
             obj(Items.GRIMY_RANARR_WEED, quantity = 1, 15)
             obj(Items.GRIMY_IRIT_LEAF, quantity = 1, 15)
             obj(Items.GRIMY_AVANTOE, quantity = 1, 15)
+            nothing(38)
         }
         table("second") {
             total(128)
@@ -32,10 +34,12 @@ val droptable =
             obj(Items.LIMPWURT_ROOT, quantity = 1, 15)
             obj(Items.EYE_OF_NEWT, quantity = 1, 15)
             obj(Items.RED_SPIDERS_EGGS, quantity = 1, 15)
+            nothing(38)
         }
         table("coins") {
             total(128)
             obj(Items.COINS, quantityRange = 25..50, 6)
+            nothing(122)
         }
     }
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/critters/deadly_red_spider_lvl34.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/critters/deadly_red_spider_lvl34.plugin.kts
@@ -15,6 +15,7 @@ val droptable =
         table("main") {
             total(128)
             obj(Items.RED_SPIDERS_EGGS, quantityRange = 1..10, 30)
+            nothing(98)
         }
     }
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/critters/giant_rat_lvl3.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/critters/giant_rat_lvl3.plugin.kts
@@ -18,6 +18,7 @@ val droptable =
             total(11)
             obj(Items.IRON_MED_HELM, quantity = 1, 1)
             obj(Items.IRON_CHAINBODY, quantity = 1, 1)
+            nothing(9)
         }
         table("rare") {
             total(128)
@@ -27,6 +28,7 @@ val droptable =
             obj(Items.IRON_PLATESKIRT, quantity = 1, 16)
             obj(Items.IRON_2H_SWORD, quantity = 1, 7)
             obj(Items.IRON_SCIMITAR, quantity = 1, 3)
+            nothing(66)
         }
     }
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/critters/ice_spider_lvl61.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/critters/ice_spider_lvl61.plugin.kts
@@ -14,12 +14,14 @@ val droptable =
             obj(Items.JANGERBERRIES, quantity = 1, 30)
             obj(Items.EYE_OF_NEWT, quantity = 1, 50)
             obj(Items.UNICORN_HORN_DUST, quantity = 1, 50)
+            nothing(1)
         }
         table("second") {
             total(128)
             obj(Items.LIMPWURT_ROOT, quantity = 1, 50)
             obj(Items.VOLCANIC_ASH, quantity = 1, 50)
             obj(Items.RED_SPIDERS_EGGS, quantity = 1, 50)
+            nothing(1)
         }
         table("herb-secondaries") {
             total(128)
@@ -27,6 +29,7 @@ val droptable =
             obj(Items.WHITE_BERRIES, quantity = 1, 40)
             obj(Items.TOADS_LEGS, quantity = 1, 40)
             obj(Items.GOAT_HORN_DUST, quantity = 1, 40)
+            nothing(1)
         }
         table("herbs") {
             total(128)
@@ -34,6 +37,7 @@ val droptable =
             obj(Items.MORT_MYRE_FUNGUS, quantity = 1, 40)
             obj(Items.DRAGON_SCALE_DUST, quantity = 1, 40)
             obj(Items.YEW_ROOTS, quantity = 1, 40)
+            nothing(1)
         }
         table("rare") {
             total(128)
@@ -42,6 +46,7 @@ val droptable =
             obj(Items.MAGIC_ROOTS, quantity = 1, 20)
             obj(Items.NIHIL_DUST, quantity = 1, 20)
             obj(Items.CRUSHED_NEST, quantity = 1, 20)
+            nothing(28)
         }
 
     }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/critters/myre_blamish_snail_lvl30.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/critters/myre_blamish_snail_lvl30.plugin.kts
@@ -17,6 +17,7 @@ val droptable =
             obj(Items.LOGS, quantityRange = 1..3, 20)
             obj(Items.BOW_STRING, quantityRange = 1..3, 22)
             obj(Items.COAL, quantityRange = 1..3, 27)
+            nothing(59)
         }
     }
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/dragons/black_dragon_lvl227.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/dragons/black_dragon_lvl227.plugin.kts
@@ -17,10 +17,12 @@ val droptable =
             obj(Items.MITHRIL_BATTLEAXE, quantity = 1, 35)
             obj(Items.ADAMANT_BATTLEAXE, quantity = 1, 30)
             obj(Items.RUNE_BATTLEAXE, quantity = 1, 28)
+            nothing(35)
         }
         table("rare") {
             total(128)
             obj(Items.DRACONIC_VISAGE, quantity = 1, 1)
+            nothing(127)
         }
         table("herbs-noted") {
             total(128)
@@ -31,6 +33,7 @@ val droptable =
             obj(Items.GRIMY_HARRALANDER_NOTED, quantityRange = 3..10, 22)
             obj(Items.GRIMY_DWARF_WEED_NOTED, quantityRange = 3..10, 10)
             obj(Items.GRIMY_TORSTOL_NOTED, quantityRange = 3..10, 9)
+            nothing(21)
         }
         table("gems") {
             total(128)
@@ -38,6 +41,7 @@ val droptable =
             obj(Items.UNCUT_EMERALD, quantity = 1, 80)
             obj(Items.UNCUT_DIAMOND, quantity = 1, 70)
             obj(Items.UNCUT_RUBY, quantity = 1, 75)
+            nothing(1)
         }
 
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/dragons/blue_dragon_lvl111.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/dragons/blue_dragon_lvl111.plugin.kts
@@ -19,28 +19,33 @@ val droptable =
             obj(Items.GRIMY_GUAM_LEAF_NOTED, quantityRange = 3..8, 20)
             obj(Items.GRIMY_MARRENTILL_NOTED, quantityRange = 3..8, 24)
             obj(Items.GRIMY_HARRALANDER_NOTED, quantityRange = 3..8, 22)
+            nothing(40)
         }
         table("gems") {
             total(128)
             obj(Items.UNCUT_SAPPHIRE, quantity = 1, 90)
             obj(Items.UNCUT_EMERALD, quantity = 1, 80)
+            nothing(1)
         }
         table("second") {
             total(128)
             obj(Items.UNCUT_RUBY, quantity = 1, 75)
             obj(Items.LIMPWURT_ROOT_NOTED, quantityRange = 2..6, 40)
             obj(Items.RED_SPIDERS_EGGS_NOTED, quantityRange = 2..6, 34)
+            nothing(1)
         }
         table("main") {
             total(128)
             obj(Items.MITHRIL_SWORD, quantity = 1, 45)
             obj(Items.ADAMANT_SWORD, quantity = 1, 40)
             obj(Items.RUNE_SWORD, quantity = 1, 28)
+            nothing(15)
         }
         table("rare") {
             total(128)
             obj(Items.WHITE_BERRIES_NOTED, quantityRange = 2..6, 22)
             obj(Items.SNAPE_GRASS_NOTED, quantityRange = 2..6, 28)
+            nothing(78)
         }
 
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/dragons/green_dragon_lvl79.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/dragons/green_dragon_lvl79.plugin.kts
@@ -18,21 +18,25 @@ val droptable =
             obj(Items.GRIMY_GUAM_LEAF_NOTED, quantityRange = 3..8, 20)
             obj(Items.GRIMY_MARRENTILL_NOTED, quantityRange = 3..8, 24)
             obj(Items.GRIMY_HARRALANDER_NOTED, quantityRange = 3..8, 22)
+            nothing(50)
         }
         table("gems") {
             total(128)
             obj(Items.UNCUT_SAPPHIRE, quantity = 1, 90)
             obj(Items.UNCUT_EMERALD, quantity = 1, 80)
+            nothing(1)
         }
         table("second") {
             total(128)
             obj(Items.LIMPWURT_ROOT_NOTED, quantityRange = 2..6, 30)
             obj(Items.RED_SPIDERS_EGGS_NOTED, quantityRange = 2..6, 28)
+            nothing(70)
         }
         table("rare") {
             total(128)
             obj(Items.WHITE_BERRIES_NOTED, quantityRange = 2..6, 18)
             obj(Items.SNAPE_GRASS_NOTED, quantityRange = 2..6, 20)
+            nothing(90)
         }
 
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/dragons/red_dragon_lvl152.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/dragons/red_dragon_lvl152.plugin.kts
@@ -15,6 +15,7 @@ val droptable =
         table("rare") {
             total(128)
             obj(Items.DRACONIC_VISAGE, quantity = 1, 1)
+            nothing(127)
         }
         table("herbs-noted") {
             total(128)
@@ -25,22 +26,26 @@ val droptable =
             obj(Items.GRIMY_HARRALANDER_NOTED, quantityRange = 3..8, 22)
             obj(Items.GRIMY_DWARF_WEED_NOTED, quantityRange = 3..8, 10)
             obj(Items.GRIMY_TORSTOL_NOTED, quantityRange = 3..8, 9)
+            nothing(21)
         }
         table("gems") {
             total(128)
             obj(Items.UNCUT_SAPPHIRE, quantity = 1, 90)
             obj(Items.UNCUT_EMERALD, quantity = 1, 80)
+            nothing(1)
         }
         table("second") {
             total(128)
             obj(Items.UNCUT_DIAMOND, quantity = 1, 70)
             obj(Items.UNCUT_RUBY, quantity = 1, 75)
+            nothing(1)
         }
         table("main") {
             total(128)
             obj(Items.MITHRIL_LONGSWORD, quantity = 1, 45)
             obj(Items.ADAMANT_LONGSWORD, quantity = 1, 40)
             obj(Items.RUNE_LONGSWORD, quantity = 1, 28)
+            nothing(15)
         }
 
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/giants/hillgiant_lvl28.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/giants/hillgiant_lvl28.plugin.kts
@@ -28,12 +28,14 @@ val droptable =
             obj(Items.DEATH_RUNE, quantityRange = 1..3, 9)
             obj(Items.BEER, quantity = 1, 12)
             obj(Items.COINS, quantityRange = 1..75, 60)
+            nothing(1)
         }
         table("rare") {
             total(128)
             obj(Items.UNCUT_DIAMOND, quantity = 1, 2)
             obj(Items.UNCUT_EMERALD, quantity = 1, 7)
             obj(Items.UNCUT_SAPPHIRE, quantity = 1, 16)
+            nothing(103)
         }
         table("second") {
             total(128)
@@ -46,6 +48,7 @@ val droptable =
             obj(Items.BLACK_AXE, quantity = 1, 6)
             obj(Items.IRON_ARROW, quantityRange = 5..15, 10)
             obj(Items.STEEL_ARROW, quantityRange = 1..15, 14)
+            nothing(73)
         }
 
     }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/giants/icegiant_lvl53.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/giants/icegiant_lvl53.plugin.kts
@@ -18,14 +18,17 @@ val droptable =
             obj(Items.WILLOW_LOGS_NOTED, quantityRange = 1..10, 1)
             obj(Items.MAPLE_LOGS_NOTED, quantityRange = 1..7, 1)
             obj(Items.YEW_LOGS_NOTED, quantityRange = 1..4, 1)
+            nothing(115)
         }
         table("rare") {
             total(128)
             obj(Items.CAPE_OF_LEGENDS, quantity = 1, 1)
+            nothing(127)
         }
         table("second") {
             total(128)
             obj(Items.LOGS_NOTED, quantityRange = 1..15, 1)
+            nothing(127)
         }
     }
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/giants/mossgiant_lvl42.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/giants/mossgiant_lvl42.plugin.kts
@@ -25,6 +25,7 @@ val droptable =
             obj(Items.CHAOS_RUNE, quantityRange = 10..50, 15)
             obj(Items.DEATH_RUNE, quantityRange = 1..25, 9)
             obj(Items.COINS, quantityRange = 100..250, 60)
+            nothing(1)
         }
         table("rare") {
             total(128)
@@ -37,6 +38,7 @@ val droptable =
             obj(Items.COAL, quantityRange = 3..25, 3)
             obj(Items.ADAMANT_PICKAXE, quantity = 1, 3)
             obj(Items.ADAMANT_AXE, quantity = 1, 3)
+            nothing(79)
         }
         table("second") {
             total(128)
@@ -44,6 +46,7 @@ val droptable =
             obj(Items.IRON_ARROW, quantityRange = 50..150, 10)
             obj(Items.STEEL_ARROW, quantityRange = 1..125, 14)
             obj(Items.UNCUT_RUBY, quantity = 1, 5)
+            nothing(96)
         }
 
     }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/golems/runite_golem_lvl178.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/golems/runite_golem_lvl178.plugin.kts
@@ -25,6 +25,7 @@ val droptable =
             obj(Items.EARTH_RUNE, quantityRange = 10..75, 15)
             obj(Items.FIRE_RUNE, quantityRange = 10..75, 15)
             obj(Items.MIND_RUNE, quantityRange = 10..75, 15)
+            nothing(1)
         }
         table("rare") {
             total(128)
@@ -34,6 +35,7 @@ val droptable =
             obj(Items.DRAGON_SWORD, quantity = 1, 4)
             obj(Items.AMULET_OF_GLORY, quantity = 1, 1)
             obj(Items.AMULET_OF_FURY, quantity = 1, 1)
+            nothing(112)
         }
 
     }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/afflicted_lvl.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/afflicted_lvl.plugin.kts
@@ -15,6 +15,7 @@ val droptable =
         table("herbs-noted") {
             total(128)
             obj(Items.GRIMY_GUAM_LEAF, quantity = 1, 88)
+            nothing(40)
         }
         guaranteed {
             obj(Items.COINS, quantityRange = 111..450)
@@ -23,29 +24,35 @@ val droptable =
         table("coins") {
             total(128)
             obj(Items.COINS, quantityRange = 100..500, 2)
+            nothing(126)
         }
         table("main") {
             total(128)
             obj(Items.GRIMY_IRIT_LEAF, quantity = 1, 85)
             obj(Items.GRIMY_LANTADYME, quantity = 1, 80)
+            nothing(1)
         }
         table("second") {
             total(128)
             obj(Items.GRIMY_HARRALANDER, quantity = 1, 75)
             obj(Items.GRIMY_CADANTINE, quantity = 1, 71)
+            nothing(1)
         }
         table("herbs") {
             total(128)
             obj(Items.GRIMY_KWUARM, quantity = 1, 67)
+            nothing(61)
         }
         table("rare") {
             total(128)
             obj(Items.GRIMY_AVANTOE, quantity = 1, 62)
             obj(Items.GRIMY_TARROMIN, quantity = 1, 77)
+            nothing(1)
         }
         table("herb-secondaries") {
             total(128)
             obj(Items.GRIMY_MARRENTILL, quantity = 1, 81)
+            nothing(47)
         }
 
     }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/archer_lvl37.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/archer_lvl37.plugin.kts
@@ -26,6 +26,7 @@ val droptable =
             obj(Items.GREEN_DHIDE_VAMBRACES, quantity = 1, 3)
             obj(Items.GREEN_DHIDE_BODY, quantity = 1, 4)
             obj(Items.GREEN_DHIDE_CHAPS, quantity = 1, 5)
+            nothing(116)
         }
         table("main") {
             total(128)
@@ -34,6 +35,7 @@ val droptable =
             obj(Items.MAPLE_SHORTBOW_U, quantity = 1, 10)
             obj(Items.IRON_ARROW, quantity = 15, 12)
             obj(Items.STEEL_ARROW, quantity = 15, 14)
+            nothing(76)
         }
     }
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/chaos_druide_lvl13.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/chaos_druide_lvl13.plugin.kts
@@ -21,12 +21,14 @@ val droptable =
             obj(Items.GRIMY_AVANTOE_NOTED, quantityRange = 1..3, 12)
             obj(Items.GRIMY_IRIT_LEAF_NOTED, quantityRange = 1..3, 12)
             obj(Items.GRIMY_KWUARM_NOTED, quantityRange = 1..3, 8)
+            nothing(24)
         }
         table("second") {
             total(128)
             obj(Items.GRIMY_CADANTINE_NOTED, quantityRange = 1..2, 8)
             obj(Items.GRIMY_DWARF_WEED_NOTED, quantityRange = 1..2, 4)
             obj(Items.GRIMY_TORSTOL_NOTED, quantityRange = 1..2, 4)
+            nothing(112)
         }
     }
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/chaosdwarf_lvl48.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/chaosdwarf_lvl48.plugin.kts
@@ -15,6 +15,7 @@ val droptable =
         table("coins") {
             total(128)
             obj(Items.COINS, quantityRange = 1..50, 80)
+            nothing(48)
         }
         table("main") {
             total(128)
@@ -25,11 +26,13 @@ val droptable =
             obj(Items.WATER_RUNE, quantityRange = 1..20, 20)
             obj(Items.MITHRIL_BAR, quantity = 1, 2)
             obj(Items.COAL, quantityRange = 1..3, 10)
+            nothing(2)
         }
         table("gems") {
             total(128)
             obj(Items.UNCUT_SAPPHIRE, quantity = 1, 20)
             obj(Items.UNCUT_EMERALD, quantity = 1, 17)
+            nothing(91)
         }
         table("second") {
             total(128)
@@ -42,6 +45,7 @@ val droptable =
             obj(Items.MITHRIL_FULL_HELM, quantity = 1, 10)
             obj(Items.MITHRIL_PLATELEGS, quantity = 1, 10)
             obj(Items.MITHRIL_PLATEBODY, quantity = 1, 10)
+            nothing(1)
         }
         table("rare") {
             total(128)
@@ -49,6 +53,7 @@ val droptable =
             obj(Items.MITHRIL_WARHAMMER, quantity = 1, 6)
             obj(Items.MITHRIL_BATTLEAXE, quantity = 1, 6)
             obj(Items.MITHRIL_SCIMITAR, quantity = 1, 6)
+            nothing(100)
         }
 
     }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/druid_lvl33.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/druid_lvl33.plugin.kts
@@ -19,6 +19,7 @@ val droptable =
             obj(Items.GRIMY_TARROMIN_NOTED, quantityRange = 1..5, 16)
             obj(Items.GRIMY_RANARR_WEED_NOTED, quantityRange = 1..5, 16)
             obj(Items.GRIMY_IRIT_LEAF_NOTED, quantityRange = 1..5, 12)
+            nothing(44)
         }
         table("second") {
             total(128)
@@ -27,6 +28,7 @@ val droptable =
             obj(Items.GRIMY_CADANTINE_NOTED, quantityRange = 1..4, 8)
             obj(Items.GRIMY_DWARF_WEED_NOTED, quantityRange = 1..4, 4)
             obj(Items.GRIMY_TORSTOL_NOTED, quantityRange = 1..3, 4)
+            nothing(92)
         }
     }
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/dwarf_gang_member_lvl49.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/dwarf_gang_member_lvl49.plugin.kts
@@ -19,6 +19,7 @@ val droptable =
             obj(Items.GOLD_BAR, quantity = 1, 20)
             obj(Items.ADAMANT_PICKAXE, quantity = 1, 17)
             obj(Items.RUNE_PICKAXE, quantity = 1, 14)
+            nothing(1)
         }
     }
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/dwarf_lvl10.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/dwarf_lvl10.plugin.kts
@@ -19,6 +19,7 @@ val droptable =
             obj(Items.IRON_ORE, quantity = 1, 10)
             obj(Items.BRONZE_PICKAXE, quantity = 1, 10)
             obj(Items.IRON_PICKAXE, quantity = 1, 10)
+            nothing(58)
         }
     }
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/elder_chaos_druid_lvl129.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/elder_chaos_druid_lvl129.plugin.kts
@@ -18,6 +18,7 @@ val droptable =
             obj(Items.ELDER_CHAOS_HOOD, quantity = 1, 1)
             obj(Items.ANCIENT_STAFF, quantity = 1, 3)
             obj(Items.ZURIELS_STAFF, quantity = 1, 1)
+            nothing(119)
         }
         table("main") {
             total(128)
@@ -32,6 +33,7 @@ val droptable =
             obj(Items.DEATH_RUNE, quantityRange = 10..15, 10)
             obj(Items.CHAOS_RUNE, quantityRange = 10..15, 10)
             obj(Items.LAW_RUNE, quantityRange = 10..15, 10)
+            nothing(18)
         }
     }
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/guard_lvl21_falador.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/guard_lvl21_falador.plugin.kts
@@ -20,10 +20,12 @@ val droptable =
             obj(Items.OAK_SHORTBOW, quantityRange = 1..0, 5)
             obj(Items.STEEL_SWORD, quantityRange = 1..0, 6)
             obj(Items.AIR_RUNE, quantityRange = 5..15, 8)
+            nothing(100)
         }
         table("coins") {
             total(128)
             obj(Items.COINS, quantityRange = 25..0, 1)
+            nothing(127)
         }
         table("second") {
             total(128)
@@ -33,6 +35,7 @@ val droptable =
             obj(Items.STEEL_CHAINBODY, quantityRange = 1..0, 4)
             obj(Items.STEEL_MACE, quantityRange = 1..0, 5)
             obj(Items.STEEL_LONGSWORD, quantityRange = 1..0, 6)
+            nothing(107)
         }
         table("rare") {
             total(128)
@@ -46,6 +49,7 @@ val droptable =
             obj(Items.STEEL_PLATEBODY, quantity = 1, 8)
             obj(Items.STEEL_SCIMITAR, quantity = 1, 9)
             obj(Items.STEEL_2H_SWORD, quantity = 1, 10)
+            nothing(73)
         }
 
     }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/hero_lvl69.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/hero_lvl69.plugin.kts
@@ -17,12 +17,14 @@ val droptable =
             obj(Items.COINS, quantityRange = 1..150, 90)
             obj(Items.AIR_RUNE, quantityRange = 1..30, 22)
             obj(Items.WATER_RUNE, quantityRange = 1..20, 18)
+            nothing(1)
         }
         table("rare") {
             total(128)
             obj(Items.GOLD_ORE, quantity = 1, 6)
             obj(Items.UNCUT_EMERALD, quantity = 1, 5)
             obj(Items.UNCUT_DIAMOND, quantity = 1, 5)
+            nothing(112)
         }
         table("second") {
             total(128)
@@ -30,6 +32,7 @@ val droptable =
             obj(Items.FIRE_RUNE, quantityRange = 1..5, 18)
             obj(Items.DEATH_RUNE, quantityRange = 1..3, 18)
             obj(Items.BLOOD_RUNE, quantityRange = 1..3, 18)
+            nothing(56)
         }
 
     }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/ice_warrior_icequeen_lvl57.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/ice_warrior_icequeen_lvl57.plugin.kts
@@ -19,6 +19,7 @@ val droptable =
             obj(Items.MARRENTILL_SEED, quantityRange = 1..3, 30)
             obj(Items.JANGERBERRY_SEED, quantityRange = 1..3, 30)
             obj(Items.TARROMIN_SEED, quantityRange = 1..3, 30)
+            nothing(1)
         }
         table("second") {
             total(128)
@@ -27,6 +28,7 @@ val droptable =
             obj(Items.SNAPE_GRASS_SEED, quantityRange = 1..2, 30)
             obj(Items.RANARR_SEED, quantityRange = 1..2, 30)
             obj(Items.WHITEBERRY_SEED, quantityRange = 1..2, 30)
+            nothing(1)
         }
         table("herbs") {
             total(128)
@@ -35,12 +37,14 @@ val droptable =
             obj(Items.POISON_IVY_SEED, quantityRange = 1..2, 30)
             obj(Items.AVANTOE_SEED, quantityRange = 1..2, 30)
             obj(Items.KWUARM_SEED, quantityRange = 1..2, 30)
+            nothing(1)
         }
         table("gems") {
             total(128)
             obj(Items.SNAPDRAGON_SEED, quantityRange = 1..2, 30)
             obj(Items.CADANTINE_SEED, quantityRange = 1..2, 30)
             obj(Items.LANTADYME_SEED, quantityRange = 1..2, 30)
+            nothing(38)
         }
 
     }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/icequeen_lvl211.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/icequeen_lvl211.plugin.kts
@@ -17,6 +17,7 @@ val droptable =
             obj(Items.ICE_GLOVES, quantity = 1, 1)
             obj(Items.NEW_CRYSTAL_BOW, quantity = 1, 1)
             obj(Items.NEW_CRYSTAL_SHIELD, quantity = 1, 1)
+            nothing(125)
         }
         table("main") {
             total(128)
@@ -25,6 +26,7 @@ val droptable =
             obj(Items.TORSTOL_NOTED, quantityRange = 1..3, 5)
             obj(Items.BLOOD_RUNE, quantityRange = 1..10, 9)
             obj(Items.DEATH_RUNE, quantityRange = 1..10, 9)
+            nothing(91)
         }
         table("second") {
             total(128)
@@ -32,6 +34,7 @@ val droptable =
             obj(Items.RUNE_ARROWTIPS, quantityRange = 1..5, 5)
             obj(Items.ADAMANT_ARROWTIPS, quantityRange = 1..5, 5)
             obj(Items.MITHRIL_ARROWTIPS, quantityRange = 1..8, 5)
+            nothing(111)
         }
 
     }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/kamil_lvl94.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/kamil_lvl94.plugin.kts
@@ -15,6 +15,7 @@ val droptable =
         table("coins") {
             total(128)
             obj(Items.COINS, quantityRange = 250..1500, 90)
+            nothing(38)
         }
         table("main") {
             total(128)
@@ -32,6 +33,7 @@ val droptable =
             obj(Items.STEEL_ARROW, quantityRange = 25..50, 15)
             obj(Items.MITHRIL_ARROW, quantityRange = 10..25, 15)
             obj(Items.ADAMANT_ARROW, quantityRange = 1..20, 10)
+            nothing(1)
         }
         table("second") {
             total(128)
@@ -40,6 +42,7 @@ val droptable =
             obj(Items.WHITE_SCIMITAR, quantity = 1, 15)
             obj(Items.WHITE_BATTLEAXE, quantity = 1, 15)
             obj(Items.WHITE_2H_SWORD, quantity = 1, 10)
+            nothing(65)
         }
         table("rare") {
             total(128)
@@ -58,6 +61,7 @@ val droptable =
             obj(Items.RUNE_LONGSWORD, quantity = 1, 7)
             obj(Items.RUNE_SWORD, quantity = 1, 7)
             obj(Items.RUNE_MACE, quantity = 1, 7)
+            nothing(37)
         }
 
     }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/monk_lvl5.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/monk_lvl5.plugin.kts
@@ -16,6 +16,7 @@ val droptable =
             total(128)
             obj(Items.MONKS_ROBE, quantity = 1, 1)
             obj(Items.MONKS_ROBE_TOP, quantity = 1, 1)
+            nothing(126)
         }
     }
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/monk_of_zamorak_lvl45.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/monk_of_zamorak_lvl45.plugin.kts
@@ -19,6 +19,7 @@ val droptable =
             obj(Items.UNICORN_HORN_DUST_NOTED, quantityRange = 1..5, 6)
             obj(Items.WHITE_BERRIES_NOTED, quantityRange = 1..5, 5)
             obj(Items.DRAGON_SCALE_DUST_NOTED, quantityRange = 1..5, 5)
+            nothing(94)
         }
     }
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/paladin_lvl62.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/paladin_lvl62.plugin.kts
@@ -28,6 +28,7 @@ val droptable =
             obj(Items.STEEL_BAR_NOTED, quantity = 1, 5)
             obj(Items.MITHRIL_BAR_NOTED, quantity = 1, 3)
             obj(Items.DRAGON_BATTLEAXE, quantity = 1, 1)
+            nothing(40)
         }
 
     }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/ungadulu_lvl70.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/ungadulu_lvl70.plugin.kts
@@ -18,6 +18,7 @@ val droptable =
                 obj(Items.BERSERKER_HELM, quantity = 1, 1)
                 obj(Items.ARCHER_HELM, quantity = 1, 1)
                 obj(Items.MIME_MASK, quantity = 1, 15)
+                nothing(111)
             }
             table("second") {
                 total(128)
@@ -25,6 +26,7 @@ val droptable =
                 obj(Items.MIME_GLOVES, quantity = 1, 15)
                 obj(Items.MIME_LEGS, quantity = 1, 15)
                 obj(Items.MIME_TOP, quantity = 1, 15)
+                nothing(68)
             }
             table("main") {
                 total(128)
@@ -36,6 +38,7 @@ val droptable =
                 obj(Items.AVANTOE_POTION_UNF_NOTED, quantityRange = 1..4, 5)
                 obj(Items.CADANTINE_POTION_UNF_NOTED, quantityRange = 1..4, 5)
                 obj(Items.RUNE_SCIMITAR, quantity = 1, 11)
+                nothing(82)
             }
         }
     }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/watchman_lvl33.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/watchman_lvl33.plugin.kts
@@ -23,6 +23,7 @@ val droptable =
             obj(Items.STEEL_PLATELEGS, quantity = 1, 14)
             obj(Items.STEEL_CHAINBODY, quantity = 1, 14)
             obj(Items.UNCUT_RED_TOPAZ, quantity = 1, 20)
+            nothing(19)
         }
     }
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/whiteknight_lvl36.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/whiteknight_lvl36.plugin.kts
@@ -25,6 +25,7 @@ val droptable =
             obj(Items.WHITE_CHAINBODY, quantity = 1, 4)
             obj(Items.WHITE_FULL_HELM, quantity = 1, 3)
             obj(Items.WHITE_PLATEBODY, quantity = 1, 3)
+            nothing(1)
         }
         table("rare") {
             total(128)
@@ -35,6 +36,7 @@ val droptable =
             obj(Items.LEATHER_CHAPS, quantity = 1, 20)
             obj(Items.STUDDED_CHAPS, quantity = 1, 20)
             obj(Items.LEATHER_VAMBRACES, quantity = 1, 20)
+            nothing(1)
         }
         table("second") {
             total(128)
@@ -45,6 +47,7 @@ val droptable =
             obj(Items.WHITE_PLATELEGS, quantity = 1, 3)
             obj(Items.WHITE_PLATESKIRT, quantity = 1, 3)
             obj(Items.WHITE_KITESHIELD, quantity = 1, 3)
+            nothing(43)
         }
 
     }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/wizard_lvl9.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/wizard_lvl9.plugin.kts
@@ -18,12 +18,14 @@ val droptable =
             obj(Items.BODY_TALISMAN, quantity = 1, 15)
             obj(Items.MIND_TALISMAN, quantity = 1, 15)
             obj(Items.BLOOD_TALISMAN, quantity = 1, 1)
+            nothing(17)
         }
         table("second") {
             total(128)
             obj(Items.CHAOS_TALISMAN, quantity = 1, 10)
             obj(Items.COSMIC_TALISMAN, quantity = 1, 10)
             obj(Items.DEATH_TALISMAN, quantity = 1, 1)
+            nothing(107)
         }
     }
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/other/abyssal_guardian.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/other/abyssal_guardian.plugin.kts
@@ -15,11 +15,13 @@ val droptable =
         table("main") {
             total(128)
             obj(Items.PURE_ESSENCE_NOTED, quantityRange = 5..15, 11)
+            nothing(117)
         }
         table("rare") {
             total(128)
             obj(Items.MEDIUM_POUCH, quantity = 1, 22)
             obj(Items.LARGE_POUCH, quantity = 1, 19)
+            nothing(87)
         }
     }
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/other/abyssal_leech.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/other/abyssal_leech.plugin.kts
@@ -15,10 +15,12 @@ val droptable =
         table("rare") {
             total(128)
             obj(Items.SMALL_POUCH, quantity = 1, 22)
+            nothing(106)
         }
         table("main") {
             total(128)
             obj(Items.PURE_ESSENCE_NOTED, quantityRange = 5..15, 11)
+            nothing(117)
         }
     }
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/other/abyssal_walker.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/other/abyssal_walker.plugin.kts
@@ -15,11 +15,13 @@ val droptable =
         table("main") {
             total(128)
             obj(Items.PURE_ESSENCE_NOTED, quantityRange = 10..22, 11)
+            nothing(117)
         }
         table("rare") {
             total(128)
             obj(Items.COLOSSAL_POUCH, quantity = 1, 19)
             obj(Items.LARGE_POUCH, quantity = 1, 25)
+            nothing(84)
         }
     }
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/other/giant_roc.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/other/giant_roc.plugin.kts
@@ -19,17 +19,20 @@ val droptable =
             obj(Items.CRYSTAL_LEGS_PERFECTED, quantity = 1, 1)
             obj(Items.ARCHERS_RING, quantity = 1, 4)
             obj(Items.NECKLACE_OF_ANGUISH, quantity = 1, 1)
+            nothing(120)
         }
         table("main") {
             total(128)
             obj(Items.RUNE_ARROW, quantityRange = 1..15, 5)
             obj(Items.ADAMANT_ARROW, quantityRange = 1..15, 10)
+            nothing(113)
         }
         table("coins") {
             total(128)
             obj(Items.COINS, quantityRange = 400..1000, 1)
             obj(Items.COINS, quantityRange = 150..300, 5)
             obj(Items.COINS, quantityRange = 200..500, 7)
+            nothing(115)
         }
 
     }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/other/hobgoblin_lvl54.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/other/hobgoblin_lvl54.plugin.kts
@@ -18,10 +18,12 @@ val droptable =
             obj(Items.GOBLIN_MAIL, quantity = 1, 30)
             obj(Items.IRON_SWORD, quantity = 1, 20)
             obj(Items.AIR_RUNE, quantityRange = 1..10, 10)
+            nothing(1)
         }
         table("second") {
             total(128)
             obj(Items.STEEL_ARROW, quantityRange = 1..5, 10)
+            nothing(118)
         }
     }
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/other/icelord_lvl151.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/other/icelord_lvl151.plugin.kts
@@ -20,6 +20,7 @@ val droptable =
             obj(Items.RUNE_BATTLEAXE, quantity = 1, 10)
             obj(Items.RUNE_WARHAMMER, quantity = 1, 10)
             obj(Items.RUNE_SCIMITAR, quantity = 1, 6)
+            nothing(77)
         }
         table("rare") {
             total(128)
@@ -28,6 +29,7 @@ val droptable =
             obj(Items.RUNE_PLATEBODY, quantity = 1, 4)
             obj(Items.RUNE_KITESHIELD, quantity = 1, 4)
             obj(Items.RUNE_FULL_HELM, quantity = 1, 4)
+            nothing(111)
         }
         table("gems") {
             total(128)
@@ -35,11 +37,13 @@ val droptable =
             obj(Items.UNCUT_RUBY, quantity = 1, 8)
             obj(Items.UNCUT_EMERALD, quantity = 1, 12)
             obj(Items.UNCUT_SAPPHIRE, quantity = 1, 15)
+            nothing(87)
         }
         table("herb-secondaries") {
             total(128)
             obj(Items.EYE_OF_NEWT, quantity = 1, 25)
             obj(Items.LIMPWURT_ROOT, quantity = 1, 25)
+            nothing(78)
         }
     }
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/other/icelord_lvl91.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/other/icelord_lvl91.plugin.kts
@@ -22,11 +22,13 @@ val droptable =
             obj(Items.AMULET_OF_STRENGTH, quantity = 1, 10)
             obj(Items.AMULET_OF_POWER, quantity = 1, 10)
             obj(Items.CHEFS_HAT, quantity = 1, 5)
+            nothing(1)
         }
         table("secondary") {
             total(128)
             obj(Items.STEEL_BOOTS, quantity = 1, 5)
             obj(Items.IRON_BOOTS, quantity = 1, 10)
+            nothing(113)
         }
     }
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/other/slagilith_lvl92.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/other/slagilith_lvl92.plugin.kts
@@ -19,6 +19,7 @@ val droptable =
             obj(Items.UNCUT_DIAMOND, quantity = 1, 70)
             obj(Items.UNCUT_RUBY, quantity = 1, 75)
             obj(Items.UNCUT_EMERALD, quantity = 1, 80)
+            nothing(1)
         }
         table("rare") {
             total(128)
@@ -27,6 +28,7 @@ val droptable =
             obj(Items.ROCKSHELL_GLOVES, quantity = 1, 13)
             obj(Items.ROCKSHELL_PLATE, quantity = 1, 14)
             obj(Items.ROCKSHELL_LEGS, quantity = 1, 15)
+            nothing(63)
         }
     }
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/trolls/griant_ice_troll_lvl171.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/trolls/griant_ice_troll_lvl171.plugin.kts
@@ -23,21 +23,25 @@ val droptable =
             obj(Items.INFINITY_GLOVES, quantity = 1, 1)
             obj(Items.INFINITY_BOTTOMS, quantity = 1, 1)
             obj(Items.BLURITE_SWORD, quantity = 1, 1)
+            nothing(120)
         }
         table("second") {
             total(128)
             obj(Items.PURE_ESSENCE_NOTED, quantityRange = 1..20, 10)
             obj(Items.COAL_NOTED, quantityRange = 1..10, 10)
             obj(Items.UNCUT_DIAMOND, quantity = 1, 10)
+            nothing(98)
         }
         table("gems") {
             total(128)
             obj(Items.UNCUT_RUBY, quantity = 1, 15)
+            nothing(113)
         }
         table("secondary") {
             total(128)
             obj(Items.OAK_LOGS_NOTED, quantityRange = 1..5, 7)
             obj(Items.WILLOW_LOGS_NOTED, quantityRange = 1..5, 4)
+            nothing(117)
         }
         }
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/trolls/ice_troll_lvl124.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/trolls/ice_troll_lvl124.plugin.kts
@@ -22,6 +22,7 @@ val droptable =
             obj(Items.RAW_COD_NOTED, quantityRange = 1..10, 10)
             obj(Items.RAW_TROUT_NOTED, quantityRange = 1..10, 10)
             obj(Items.RAW_SWORDFISH, quantityRange = 1..6, 4)
+            nothing(75)
         }
         }
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/undead/feral_vampyre_lvl61.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/undead/feral_vampyre_lvl61.plugin.kts
@@ -17,18 +17,21 @@ val droptable =
             obj(Items.GRIMY_GUAM_LEAF, quantity = 1, 60)
             obj(Items.GRIMY_MARRENTILL, quantity = 1, 52)
             obj(Items.GRIMY_TARROMIN, quantity = 1, 48)
+            nothing(1)
         }
         table("herb-secondaries") {
             total(128)
             obj(Items.RANARR_SEED, quantity = 1, 39)
             obj(Items.TARROMIN_SEED, quantity = 1, 42)
             obj(Items.KWUARM_SEED, quantity = 1, 33)
+            nothing(14)
         }
         table("herbs-noted") {
             total(128)
             obj(Items.GRIMY_HARRALANDER, quantity = 1, 44)
             obj(Items.GRIMY_RANARR_WEED, quantity = 1, 37)
             obj(Items.GRIMY_CADANTINE, quantity = 1, 31)
+            nothing(16)
         }
         table("second") {
             total(128)
@@ -39,6 +42,7 @@ val droptable =
             obj(Items.UNCUT_RUBY, quantity = 1, 14)
             obj(Items.CHAOS_TALISMAN, quantity = 1, 17)
             obj(Items.NATURE_TALISMAN, quantity = 1, 20)
+            nothing(4)
         }
     }
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/undead/loar_shade_lvl40.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/undead/loar_shade_lvl40.plugin.kts
@@ -24,6 +24,7 @@ val droptable =
         table("coins") {
             total(128)
             obj(Items.COINS, quantityRange = 1100..3500, 2)
+            nothing(126)
         }
         table("main") {
             total(128)
@@ -31,6 +32,7 @@ val droptable =
             obj(Items.GRIMY_MARRENTILL, quantityRange = 1..9, 18)
             obj(Items.GRIMY_TARROMIN, quantityRange = 1..9, 19)
             obj(Items.GRIMY_RANARR_WEED, quantityRange = 1..9, 17)
+            nothing(54)
         }
         table("second") {
             total(128)
@@ -43,6 +45,7 @@ val droptable =
             obj(Items.GRIMY_HARRALANDER, quantityRange = 1..5, 21)
             obj(Items.GRIMY_LANTADYME, quantityRange = 1..4, 22)
             obj(Items.GRIMY_TOADFLAX, quantityRange = 1..3, 24)
+            nothing(1)
         }
 
     }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/undead/vampyre_juvinate_lvl75.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/undead/vampyre_juvinate_lvl75.plugin.kts
@@ -23,6 +23,7 @@ val droptable =
             obj(Items.ADAMANT_SCIMITAR, quantity = 1, 12)
             obj(Items.STAFF_OF_AIR, quantity = 1, 3)
             obj(Items.STAFF_OF_EARTH, quantity = 1, 5)
+            nothing(9)
         }
         table("second") {
             total(128)
@@ -32,16 +33,19 @@ val droptable =
             obj(Items.STEEL_PLATEBODY, quantity = 1, 24)
             obj(Items.STEEL_PLATESKIRT, quantity = 1, 25)
             obj(Items.MITHRIL_KITESHIELD, quantity = 1, 26)
+            nothing(1)
         }
         table("herbs-noted") {
             total(128)
             obj(Items.WILLOW_LOGS, quantity = 5, 20)
             obj(Items.YEW_LOGS, quantity = 5, 12)
+            nothing(96)
         }
         table("rare") {
             total(128)
             obj(Items.NATURE_RUNE, quantity = 10, 12)
             obj(Items.AMULET_OF_MAGIC, quantity = 1, 1)
+            nothing(115)
         }
 
     }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/undead/vyrewatch_lvl87.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/undead/vyrewatch_lvl87.plugin.kts
@@ -15,10 +15,12 @@ val droptable =
             obj(Items.ADAMANT_PLATELEGS, quantity = 1, 17)
             obj(Items.RUNE_PLATELEGS, quantity = 1, 13)
             obj(Items.RUNE_FULL_HELM, quantity = 1, 12)
+            nothing(70)
         }
         table("coins") {
             total(128)
             obj(Items.COINS, quantity = 3500, 3)
+            nothing(125)
         }
         guaranteed {
             obj(Items.COINS, quantityRange = 2200..4500)
@@ -34,6 +36,7 @@ val droptable =
             obj(Items.KWUARM_SEED, quantityRange = 1..6, 19)
             obj(Items.SNAPDRAGON_SEED, quantityRange = 1..6, 20)
             obj(Items.CADANTINE_SEED, quantityRange = 1..4, 21)
+            nothing(1)
         }
         table("rare") {
             total(128)
@@ -42,6 +45,7 @@ val droptable =
             obj(Items.LANTADYME_SEED, quantityRange = 1..4, 24)
             obj(Items.TOADFLAX_SEED, quantityRange = 1..4, 25)
             obj(Items.HARRALANDER_SEED, quantityRange = 1..7, 26)
+            nothing(8)
         }
 
     }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/undead/zombie_lvl30.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/undead/zombie_lvl30.plugin.kts
@@ -21,6 +21,7 @@ val droptable =
             obj(Items.UNCUT_SAPPHIRE, quantity = 1, 12)
             obj(Items.TIN_ORE, quantity = 1, 6)
             obj(Items.EYE_OF_NEWT, quantity = 1, 6)
+            nothing(88)
         }
         table("coins") {
             total(128)
@@ -29,6 +30,7 @@ val droptable =
             obj(Items.COINS, quantity = 26, 25)
             obj(Items.COINS, quantity = 35, 20)
             obj(Items.COINS, quantity = 1, 2)
+            nothing(11)
         }
         table("herbs") {
             total(128)
@@ -42,12 +44,14 @@ val droptable =
             obj(Items.GRIMY_KWUARM, quantity = 1, 15)
             obj(Items.GRIMY_CADANTINE, quantity = 1, 15)
             obj(Items.GRIMY_DWARF_WEED, quantity = 1, 15)
+            nothing(1)
         }
         table("main") {
             total(128)
             obj(Items.IRON_MACE, quantity = 1, 15)
             obj(Items.IRON_DAGGER, quantity = 1, 15)
             obj(Items.BRONZE_KITESHIELD, quantity = 1, 15)
+            nothing(83)
         }
 
     }


### PR DESCRIPTION
## Summary
- add `nothing` entries to each non-guaranteed NPC drop table so they can roll no drop results

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dae55724a083299f1874471cad7d5a