### PR TITLE
Reset autocast when equipping non-magic weapons

### DIFF
--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/combat/autocast/Autocast.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/combat/autocast/Autocast.kt
@@ -1,8 +1,10 @@
 package org.alter.plugins.content.combat.autocast
 
 import org.alter.api.EquipmentType
+import org.alter.api.WeaponType
 import org.alter.api.ext.getVarbit
 import org.alter.api.ext.hasEquipped
+import org.alter.api.ext.hasWeaponType
 import org.alter.api.ext.setVarbit
 import org.alter.game.model.entity.Player
 import org.alter.plugins.content.combat.Combat
@@ -15,6 +17,9 @@ object Autocast {
 
     /** Returns true if the player's equipped weapon can autocast [spell]. */
     fun canAutocast(player: Player, spell: CombatSpell): Boolean {
+        if (!player.hasWeaponType(WeaponType.MAGIC_STAFF)) {
+            return false
+        }
         val allowed = AutocastSpells.allowedStaves(spell) ?: return true
         return player.hasEquipped(EquipmentType.WEAPON, *allowed)
     }


### PR DESCRIPTION
## Summary
- ensure autocast selections require a magic staff to remain active
- clear autocast state when swapping to weapons that cannot autocast

## Testing
- Not run (gradle wrapper script is not present in the repository)


------
https://chatgpt.com/codex/tasks/task_e_68dc1b9504188329b15cebee4077c9b2