### PR TITLE
Allow bank item moves to any slot

### DIFF
--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/bank/bank.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/bank/bank.plugin.kts
@@ -354,7 +354,13 @@ on_component_to_component_item_swap(
         return@on_component_to_component_item_swap
     }
 
-    if (srcSlot in 0 until container.occupiedSlotCount && dstSlot in 0 until container.occupiedSlotCount) {
+    val hasValidSrc = srcSlot in 0 until container.capacity
+    val hasValidDst = dstSlot in 0 until container.capacity
+
+    if (hasValidSrc && hasValidDst) {
+        if (container[srcSlot] == null) {
+            return@on_component_to_component_item_swap
+        }
         val insertMode = player.getVarbit(REARRANGE_MODE_VARBIT) == 1
         if (!insertMode) {
             container.swap(srcSlot, dstSlot)


### PR DESCRIPTION
## Summary
- allow bank drag and drop handlers to accept any valid slot so items can be moved freely
- guard against invalid source slots while keeping existing fallback syncing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc29212c888329b10526ab22771c1c