### PR TITLE
Add necromancer and magic NPC configs

### DIFF
--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/ancient_wizard_mage_combat.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/ancient_wizard_mage_combat.plugin.kts
@@ -1,0 +1,65 @@
+package org.alter.plugins.content.npcs.human
+
+import org.alter.game.model.combat.AttackStyle
+import org.alter.game.model.combat.CombatClass
+import org.alter.game.model.combat.CombatStyle
+import org.alter.game.model.entity.Npc
+import org.alter.game.model.entity.Pawn
+import org.alter.game.model.entity.Player
+import org.alter.game.model.queue.QueueTask
+import org.alter.plugins.content.combat.*
+import org.alter.plugins.content.combat.formula.MagicCombatFormula
+import org.alter.plugins.content.combat.strategy.RangedCombatStrategy
+import org.alter.api.ProjectileType
+import org.alter.api.HitType
+import org.alter.api.cfg.Animation
+import org.alter.api.cfg.Graphic
+import org.alter.api.cfg.Npcs
+
+on_npc_combat(Npcs.ANCIENT_WIZARD) {
+    npc.queue {
+        ancientWizardCombat(this)
+    }
+}
+
+suspend fun ancientWizardCombat(task: QueueTask) {
+    val npc = task.npc
+    var target = npc.getCombatTarget() ?: return
+
+    while (npc.canEngageCombat(target)) {
+        npc.facePawn(target)
+        if (npc.moveToAttackRange(task, target, distance = 10, projectile = true) && npc.isAttackDelayReady()) {
+            iceBlitz(npc, target)
+            npc.postAttackLogic(target)
+        }
+        task.wait(1)
+        target = npc.getCombatTarget() ?: break
+    }
+
+    npc.resetFacePawn()
+    npc.removeCombatTarget()
+}
+
+fun iceBlitz(npc: Npc, target: Pawn) {
+    val minHit = 4
+    val maxHit = 18
+    val projectile = npc.createProjectile(target, gfx = Graphic.ICE_RUSH_PROJECTILE, type = ProjectileType.MAGIC)
+    npc.prepareAttack(CombatClass.MAGIC, CombatStyle.MAGIC, AttackStyle.ACCURATE)
+    npc.animate(Animation.ANCIENT_SPELL_SINGLE_CAST)
+    world.spawn(projectile)
+    val hitDelay = RangedCombatStrategy.getHitDelay(npc.getFrontFacingTile(target), target.getCentreTile()) - 1
+    if (MagicCombatFormula.getAccuracy(npc, target) >= world.randomDouble()) {
+        val damage = world.random(minHit..maxHit)
+        target.hit(damage = damage, type = HitType.HIT, delay = hitDelay)
+        target.graphic(id = Graphic.ICE_BLITZ_HIT, height = 124, delay = hitDelay)
+        if (target is Player) {
+            target.freeze(cycles = 25) {
+                target.message("You feel a freezing cold run down your spine!")
+            }
+        } else {
+            target.freeze(cycles = 25)
+        }
+    } else {
+        target.hit(damage = 0, type = HitType.BLOCK, delay = hitDelay)
+    }
+}

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/ancient_wizard_mage_lvl98.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/ancient_wizard_mage_lvl98.plugin.kts
@@ -1,0 +1,92 @@
+package org.alter.plugins.content.npcs.human
+
+import org.alter.api.cfg.Animation
+import org.alter.api.cfg.Items
+import org.alter.api.cfg.Npcs
+import org.alter.api.cfg.Sound
+import org.alter.game.model.entity.Player
+import org.alter.plugins.content.drops.DropTableFactory
+
+val ancientWizardMageIds = intArrayOf(
+    Npcs.ANCIENT_WIZARD
+)
+
+private val ancientWizardTable = DropTableFactory
+val ancientWizardDrops =
+    ancientWizardTable.build {
+        guaranteed {
+            obj(Items.BONES, quantity = 1)
+        }
+        table("main") {
+            total(683)
+            obj(Items.GRIMY_TARROMIN, quantity = 1, 7)
+            obj(Items.GRIMY_HARRALANDER, quantity = 1, 6)
+            obj(Items.GRIMY_RANARR_WEED, quantity = 1, 4)
+            obj(Items.GRIMY_IRIT_LEAF, quantity = 1, 3)
+            obj(Items.GRIMY_AVANTOE, quantity = 1, 2)
+            obj(Items.GRIMY_KWUARM, quantity = 1, 2)
+            obj(Items.GRIMY_CADANTINE, quantity = 1, 2)
+            obj(Items.GRIMY_LANTADYME, quantity = 1, 1)
+            obj(Items.GRIMY_DWARF_WEED, quantity = 1, 1)
+            obj(Items.POTATO_SEED_5318, quantityRange = 1..4, 15)
+            obj(Items.FIRE_BATTLESTAFF, quantity = 1, 10)
+            obj(Items.ONION_SEED_5319, quantityRange = 1..3, 8)
+            obj(Items.CABBAGE_SEED_5324, quantityRange = 1..3, 4)
+            obj(Items.TOMATO_SEED_5322, quantityRange = 1..2, 2)
+            obj(Items.SWEETCORN_SEED_5320, quantityRange = 1..2, 1)
+            obj(Items.STRAWBERRY_SEED_5323, quantity = 1, 1)
+            obj(Items.WATERMELON_SEED_5321, quantity = 1, 1)
+            obj(Items.SNAPE_GRASS_SEED, quantity = 1, 1)
+            obj(Items.COINS, quantityRange = 50..249, 102)
+            obj(Items.PRAYER_POTION4, quantity = 1, 20)
+            obj(Items.PURE_ESSENCE, quantity = 25, 72)
+            obj(Items.STAFF_OF_FIRE, quantity = 1, 10)
+            obj(Items.RUNITE_CROSSBOW_U, quantity = 1, 10)
+            obj(Items.LOOTING_BAG, quantity = 1, 171)
+            obj(Items.AIR_RUNE, quantityRange = 5..24, 51)
+            obj(Items.FIRE_RUNE, quantityRange = 5..24, 51)
+            obj(Items.DEATH_RUNE, quantityRange = 5..24, 51)
+            obj(Items.RUNITE_BOLTS, quantityRange = 1..5, 51)
+            obj(Items.GRIMY_GUAM_LEAF, quantity = 1, 13)
+            obj(Items.GRIMY_MARRENTILL, quantity = 1, 10)
+        }
+    }
+
+ancientWizardTable.register(ancientWizardDrops, *ancientWizardMageIds)
+
+on_npc_pre_death(*ancientWizardMageIds) {
+    npc.damageMap.getMostDamage() as? Player
+}
+
+on_npc_death(*ancientWizardMageIds) {
+    ancientWizardTable.getDrop(world, npc.damageMap.getMostDamage()!! as Player, npc.id, npc.tile)
+}
+
+ancientWizardMageIds.forEach { id ->
+    set_combat_def(id) {
+        configs {
+            attackSpeed = 4
+            respawnDelay = 30
+            poisonChance = 0.0
+            venomChance = 0.0
+        }
+        stats {
+            hitpoints = 80
+            attack = 50
+            strength = 30
+            defence = 20
+            magic = 150
+            ranged = 1
+        }
+        anims {
+            attack = Animation.HUMAN_PUNCH
+            block = Animation.HUMAN_DEFEND
+            death = Animation.HUMAN_DEATH
+        }
+        sound {
+            attackSound = Sound.HUMAN_ATTACK
+            blockSound = Sound.HUMAN_BLOCK_1
+            deathSound = Sound.HUMAN_DEATH
+        }
+    }
+}

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/infernal_mage_combat.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/infernal_mage_combat.plugin.kts
@@ -1,0 +1,60 @@
+package org.alter.plugins.content.npcs.human
+
+import org.alter.game.model.combat.AttackStyle
+import org.alter.game.model.combat.CombatClass
+import org.alter.game.model.combat.CombatStyle
+import org.alter.game.model.entity.Npc
+import org.alter.game.model.entity.Pawn
+import org.alter.game.model.queue.QueueTask
+import org.alter.plugins.content.combat.*
+import org.alter.plugins.content.combat.formula.MagicCombatFormula
+import org.alter.plugins.content.combat.strategy.RangedCombatStrategy
+import org.alter.api.ProjectileType
+import org.alter.api.HitType
+import org.alter.api.cfg.Animation
+import org.alter.api.cfg.Graphic
+import org.alter.api.cfg.Npcs
+
+infernalMageIds.forEach { npcId ->
+    on_npc_combat(npcId) {
+        npc.queue {
+            infernalMageCombat(this)
+        }
+    }
+}
+
+suspend fun infernalMageCombat(task: QueueTask) {
+    val npc = task.npc
+    var target = npc.getCombatTarget() ?: return
+
+    while (npc.canEngageCombat(target)) {
+        npc.facePawn(target)
+        if (npc.moveToAttackRange(task, target, distance = 8, projectile = true) && npc.isAttackDelayReady()) {
+            fireBlast(npc, target)
+            npc.postAttackLogic(target)
+        }
+        task.wait(1)
+        target = npc.getCombatTarget() ?: break
+    }
+
+    npc.resetFacePawn()
+    npc.removeCombatTarget()
+}
+
+fun fireBlast(npc: Npc, target: Pawn) {
+    val minHit = 1
+    val maxHit = 8
+    val projectile = npc.createProjectile(target, gfx = Graphic.FIRE_BLAST_PROJECTILE, type = ProjectileType.MAGIC)
+    npc.prepareAttack(CombatClass.MAGIC, CombatStyle.MAGIC, AttackStyle.ACCURATE)
+    npc.animate(Animation.STAFF_MAGIC_SPELL_CAST)
+    npc.graphic(Graphic.FIRE_BLAST_CAST, height = 124)
+    world.spawn(projectile)
+    val hitDelay = RangedCombatStrategy.getHitDelay(npc.getFrontFacingTile(target), target.getCentreTile()) - 1
+    if (MagicCombatFormula.getAccuracy(npc, target) >= world.randomDouble()) {
+        val damage = world.random(minHit..maxHit)
+        target.hit(damage = damage, type = HitType.HIT, delay = hitDelay)
+        target.graphic(id = Graphic.FIRE_BLAST_HIT, height = 124, delay = hitDelay)
+    } else {
+        target.hit(damage = 0, type = HitType.BLOCK, delay = hitDelay)
+    }
+}

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/infernal_mage_combat.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/infernal_mage_combat.plugin.kts
@@ -15,6 +15,13 @@ import org.alter.api.cfg.Animation
 import org.alter.api.cfg.Graphic
 import org.alter.api.cfg.Npcs
 
+val infernalMageIds = intArrayOf(
+    Npcs.INFERNAL_MAGE_443,
+    Npcs.INFERNAL_MAGE_444,
+    Npcs.INFERNAL_MAGE_445,
+    Npcs.INFERNAL_MAGE_446,
+    Npcs.INFERNAL_MAGE_447
+)
 infernalMageIds.forEach { npcId ->
     on_npc_combat(npcId) {
         npc.queue {

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/infernal_mage_lvl66.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/infernal_mage_lvl66.plugin.kts
@@ -1,0 +1,92 @@
+package org.alter.plugins.content.npcs.human
+
+import org.alter.api.cfg.Animation
+import org.alter.api.cfg.Items
+import org.alter.api.cfg.Npcs
+import org.alter.api.cfg.Sound
+import org.alter.game.model.entity.Player
+import org.alter.plugins.content.drops.DropTableFactory
+
+val infernalMageIds = intArrayOf(
+    Npcs.INFERNAL_MAGE_443,
+    Npcs.INFERNAL_MAGE_444,
+    Npcs.INFERNAL_MAGE_445,
+    Npcs.INFERNAL_MAGE_446,
+    Npcs.INFERNAL_MAGE_447
+)
+
+private val infernalMageTable = DropTableFactory
+val infernalMageDrops =
+    infernalMageTable.build {
+        guaranteed {
+            obj(Items.BONES, quantity = 1)
+        }
+        table("main") {
+            total(512)
+            obj(Items.AIR_RUNE, quantity = 10, 12)
+            obj(Items.WATER_RUNE, quantity = 10, 12)
+            obj(Items.AIR_RUNE, quantity = 18, 8)
+            obj(Items.WATER_RUNE, quantity = 18, 8)
+            obj(Items.EARTH_RUNE, quantity = 18, 8)
+            obj(Items.FIRE_RUNE, quantity = 18, 8)
+            obj(Items.MIND_RUNE, quantity = 18, 8)
+            obj(Items.BODY_RUNE, quantity = 18, 8)
+            obj(Items.BLOOD_RUNE, quantity = 4, 8)
+            obj(Items.DEATH_RUNE, quantity = 7, 72)
+            obj(Items.MYSTIC_BOOTS_DARK, quantity = 1, 1)
+            obj(Items.COINS, quantity = 1, 76)
+            obj(Items.COINS, quantity = 2, 56)
+            obj(Items.COINS, quantity = 4, 32)
+            obj(Items.COINS, quantity = 29, 12)
+            obj(Items.MYSTIC_HAT_DARK, quantity = 1, 1)
+            obj(Items.STAFF, quantity = 1, 32)
+            obj(Items.STAFF_OF_FIRE, quantity = 1, 4)
+            obj(Items.LAVA_BATTLESTAFF, quantity = 1, 1)
+            obj(Items.EARTH_RUNE, quantity = 10, 24)
+            obj(Items.FIRE_RUNE, quantity = 10, 24)
+            obj(Items.EARTH_RUNE, quantity = 36, 16)
+            nothing(81)
+        }
+    }
+
+infernalMageTable.register(infernalMageDrops, *infernalMageIds)
+
+on_npc_pre_death(*infernalMageIds) {
+    npc.damageMap.getMostDamage() as? Player
+}
+
+on_npc_death(*infernalMageIds) {
+    infernalMageTable.getDrop(world, npc.damageMap.getMostDamage()!! as Player, npc.id, npc.tile)
+}
+
+infernalMageIds.forEach { id ->
+    set_combat_def(id) {
+        configs {
+            attackSpeed = 4
+            respawnDelay = 30
+            poisonChance = 0.0
+            venomChance = 0.0
+        }
+        stats {
+            hitpoints = 60
+            attack = 1
+            strength = 1
+            defence = 60
+            magic = 75
+            ranged = 1
+        }
+        bonuses {
+            defenceMagic = 40
+        }
+        anims {
+            attack = Animation.HUMAN_PUNCH
+            block = Animation.HUMAN_DEFEND
+            death = Animation.HUMAN_DEATH
+        }
+        sound {
+            attackSound = Sound.HUMAN_ATTACK
+            blockSound = Sound.HUMAN_BLOCK_1
+            deathSound = Sound.HUMAN_DEATH
+        }
+    }
+}

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/necromancer_kourend_combat.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/necromancer_kourend_combat.plugin.kts
@@ -1,0 +1,59 @@
+package org.alter.plugins.content.npcs.human
+
+import org.alter.game.model.combat.AttackStyle
+import org.alter.game.model.combat.CombatClass
+import org.alter.game.model.combat.CombatStyle
+import org.alter.game.model.entity.Npc
+import org.alter.game.model.entity.Pawn
+import org.alter.game.model.queue.QueueTask
+import org.alter.plugins.content.combat.*
+import org.alter.plugins.content.combat.formula.MagicCombatFormula
+import org.alter.plugins.content.combat.strategy.RangedCombatStrategy
+import org.alter.api.ProjectileType
+import org.alter.api.HitType
+import org.alter.api.cfg.Animation
+import org.alter.api.cfg.Graphic
+import org.alter.api.cfg.Npcs
+
+on_npc_combat(Npcs.NECROMANCER_11088) {
+    npc.queue {
+        combatLoop(this)
+    }
+}
+
+suspend fun combatLoop(task: QueueTask) {
+    val npc = task.npc
+    var target = npc.getCombatTarget() ?: return
+
+    while (npc.canEngageCombat(target)) {
+        npc.facePawn(target)
+        if (npc.moveToAttackRange(task, target, distance = 8, projectile = true) && npc.isAttackDelayReady()) {
+            fireStrike(npc, target)
+            npc.postAttackLogic(target)
+        }
+        task.wait(1)
+        target = npc.getCombatTarget() ?: break
+    }
+
+    npc.resetFacePawn()
+    npc.removeCombatTarget()
+}
+
+fun fireStrike(npc: Npc, target: Pawn) {
+    val minHit = 1
+    val maxHit = 7
+    val projectile = npc.createProjectile(target, gfx = Graphic.FIRE_STRIKE_PROJECTILE, type = ProjectileType.MAGIC)
+    npc.prepareAttack(CombatClass.MAGIC, CombatStyle.MAGIC, AttackStyle.ACCURATE)
+    npc.animate(Animation.STAFF_MAGIC_SPELL_CAST)
+    npc.graphic(Graphic.FIRE_STRIKE_CAST, height = 124)
+    world.spawn(projectile)
+    val hitDelay = RangedCombatStrategy.getHitDelay(npc.getFrontFacingTile(target), target.getCentreTile()) - 1
+    val accuracy = MagicCombatFormula.getAccuracy(npc, target)
+    if (accuracy >= world.randomDouble()) {
+        val damage = world.random(minHit..maxHit)
+        target.hit(damage = damage, type = HitType.HIT, delay = hitDelay)
+        target.graphic(id = Graphic.FIRE_STRIKE_HIT, height = 124, delay = hitDelay)
+    } else {
+        target.hit(damage = 0, type = HitType.BLOCK, delay = hitDelay)
+    }
+}

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/necromancer_kourend_lvl68.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/necromancer_kourend_lvl68.plugin.kts
@@ -1,0 +1,89 @@
+package org.alter.plugins.content.npcs.human
+
+import org.alter.api.cfg.Animation
+import org.alter.api.cfg.Items
+import org.alter.api.cfg.Npcs
+import org.alter.api.cfg.Sound
+import org.alter.game.model.entity.Player
+import org.alter.plugins.content.drops.DropTableFactory
+
+val kourendNecromancerIds = intArrayOf(
+    Npcs.NECROMANCER_11088
+)
+
+private val kourendTable = DropTableFactory
+val kourendDrops =
+    kourendTable.build {
+        guaranteed {
+            obj(Items.BONES, quantity = 1)
+        }
+        table("main") {
+            total(256)
+            obj(Items.NATURE_RUNE, quantityRange = 10..15, 15)
+            obj(Items.LAW_RUNE, quantityRange = 10..15, 15)
+            obj(Items.DEATH_RUNE, quantityRange = 4..8, 10)
+            obj(Items.BLOOD_RUNE, quantityRange = 4..8, 10)
+            obj(Items.COINS, quantityRange = 10..50, 10)
+            obj(Items.STAFF, quantity = 1, 10)
+            obj(Items.AIR_TALISMAN, quantity = 1, 5)
+            obj(Items.WATER_TALISMAN, quantity = 1, 5)
+            obj(Items.EARTH_TALISMAN, quantity = 1, 5)
+            obj(Items.FIRE_TALISMAN, quantity = 1, 5)
+            obj(Items.AIR_RUNE, quantityRange = 20..30, 20)
+            obj(Items.CLUE_SCROLL_MEDIUM, quantity = 1, 2)
+            obj(Items.WATER_RUNE, quantityRange = 20..30, 20)
+            obj(Items.EARTH_RUNE, quantityRange = 20..30, 20)
+            obj(Items.FIRE_RUNE, quantityRange = 20..30, 20)
+            obj(Items.MIND_RUNE, quantityRange = 20..30, 20)
+            obj(Items.BODY_RUNE, quantityRange = 20..30, 20)
+            obj(Items.COSMIC_RUNE, quantityRange = 10..15, 15)
+            obj(Items.CHAOS_RUNE, quantityRange = 10..15, 15)
+            nothing(14)
+        }
+    }
+
+kourendTable.register(kourendDrops, *kourendNecromancerIds)
+
+on_npc_pre_death(*kourendNecromancerIds) {
+    npc.damageMap.getMostDamage() as? Player
+}
+
+on_npc_death(*kourendNecromancerIds) {
+    kourendTable.getDrop(world, npc.damageMap.getMostDamage()!! as Player, npc.id, npc.tile)
+}
+
+kourendNecromancerIds.forEach { id ->
+    set_combat_def(id) {
+        configs {
+            attackSpeed = 4
+            respawnDelay = 30
+            poisonChance = 0.0
+            venomChance = 0.0
+        }
+        stats {
+            hitpoints = 80
+            attack = 56
+            strength = 56
+            defence = 50
+            magic = 60
+            ranged = 1
+        }
+        bonuses {
+            attackMagic = 10
+            defenceStab = 8
+            defenceSlash = 8
+            defenceCrush = 8
+            defenceMagic = 4
+        }
+        anims {
+            attack = Animation.HUMAN_PUNCH
+            block = Animation.HUMAN_DEFEND
+            death = Animation.HUMAN_DEATH
+        }
+        sound {
+            attackSound = Sound.HUMAN_ATTACK
+            blockSound = Sound.HUMAN_BLOCK_1
+            deathSound = Sound.HUMAN_DEATH
+        }
+    }
+}

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/necromancer_lvl26.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/human/necromancer_lvl26.plugin.kts
@@ -1,0 +1,82 @@
+package org.alter.plugins.content.npcs.human
+
+import org.alter.api.cfg.Animation
+import org.alter.api.cfg.Items
+import org.alter.api.cfg.Npcs
+import org.alter.api.cfg.Sound
+import org.alter.game.model.entity.Player
+import org.alter.plugins.content.drops.DropTableFactory
+
+val necromancerIds = intArrayOf(
+    Npcs.NECROMANCER
+)
+
+private val necromancerTable = DropTableFactory
+val necromancerDrops =
+    necromancerTable.build {
+        guaranteed {
+            obj(Items.BONES, quantity = 1)
+        }
+        table("main") {
+            total(256)
+            obj(Items.NATURE_RUNE, quantityRange = 10..15, 15)
+            obj(Items.LAW_RUNE, quantityRange = 10..15, 15)
+            obj(Items.DEATH_RUNE, quantityRange = 4..8, 10)
+            obj(Items.BLOOD_RUNE, quantityRange = 4..8, 10)
+            obj(Items.COINS, quantityRange = 10..50, 10)
+            obj(Items.STAFF, quantity = 1, 10)
+            obj(Items.AIR_TALISMAN, quantity = 1, 5)
+            obj(Items.WATER_TALISMAN, quantity = 1, 5)
+            obj(Items.EARTH_TALISMAN, quantity = 1, 5)
+            obj(Items.FIRE_TALISMAN, quantity = 1, 5)
+            obj(Items.AIR_RUNE, quantityRange = 20..30, 20)
+            obj(Items.CLUE_SCROLL_MEDIUM, quantity = 1, 2)
+            obj(Items.WATER_RUNE, quantityRange = 20..30, 20)
+            obj(Items.EARTH_RUNE, quantityRange = 20..30, 20)
+            obj(Items.FIRE_RUNE, quantityRange = 20..30, 20)
+            obj(Items.MIND_RUNE, quantityRange = 20..30, 20)
+            obj(Items.BODY_RUNE, quantityRange = 20..30, 20)
+            obj(Items.COSMIC_RUNE, quantityRange = 10..15, 15)
+            obj(Items.CHAOS_RUNE, quantityRange = 10..15, 15)
+            nothing(14)
+        }
+    }
+
+necromancerTable.register(necromancerDrops, *necromancerIds)
+
+on_npc_pre_death(*necromancerIds) {
+    npc.damageMap.getMostDamage() as? Player
+}
+
+on_npc_death(*necromancerIds) {
+    necromancerTable.getDrop(world, npc.damageMap.getMostDamage()!! as Player, npc.id, npc.tile)
+}
+
+necromancerIds.forEach { id ->
+    set_combat_def(id) {
+        configs {
+            attackSpeed = 4
+            respawnDelay = 30
+            poisonChance = 0.0
+            venomChance = 0.0
+        }
+        stats {
+            hitpoints = 40
+            attack = 18
+            strength = 18
+            defence = 18
+            magic = 18
+            ranged = 1
+        }
+        anims {
+            attack = Animation.HUMAN_PUNCH
+            block = Animation.HUMAN_DEFEND
+            death = Animation.HUMAN_DEATH
+        }
+        sound {
+            attackSound = Sound.HUMAN_ATTACK
+            blockSound = Sound.HUMAN_BLOCK_1
+            deathSound = Sound.HUMAN_DEATH
+        }
+    }
+}

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/other/scarred_lesser_demon.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/other/scarred_lesser_demon.plugin.kts
@@ -1,0 +1,99 @@
+package org.alter.plugins.content.npcs.other
+
+import org.alter.api.cfg.Animation
+import org.alter.api.cfg.Items
+import org.alter.api.cfg.Npcs
+import org.alter.api.cfg.Sound
+import org.alter.game.model.entity.Player
+import org.alter.plugins.content.drops.DropTableFactory
+
+val scarredLesserDemonIds = intArrayOf(
+    Npcs.SCARRED_LESSER_DEMON,
+    Npcs.SCARRED_LESSER_DEMON_12362,
+    Npcs.SCARRED_LESSER_DEMON_12364,
+    Npcs.SCARRED_LESSER_DEMON_12378,
+    Npcs.SCARRED_LESSER_DEMON_12390
+)
+
+private val scarredDemonTable = DropTableFactory
+val scarredDemonDrops =
+    scarredDemonTable.build {
+        guaranteed {
+            obj(Items.VILE_ASHES, quantity = 1)
+        }
+        table("main") {
+            total(697)
+            obj(Items.LOOTING_BAG, quantity = 1, 171)
+            obj(Items.COINS, quantity = 120, 160)
+            obj(Items.COINS, quantity = 40, 116)
+            obj(Items.COINS, quantity = 200, 40)
+            obj(Items.FIRE_RUNE, quantity = 60, 32)
+            obj(Items.COINS, quantity = 10, 28)
+            obj(Items.CHAOS_RUNE, quantity = 12, 20)
+            obj(Items.STEEL_FULL_HELM, quantity = 1, 16)
+            obj(Items.STEEL_AXE, quantity = 1, 16)
+            obj(Items.DEATH_RUNE, quantity = 3, 12)
+            obj(Items.JUG_OF_WINE, quantity = 1, 12)
+            obj(Items.STEEL_SCIMITAR, quantity = 1, 12)
+            obj(Items.ENSOULED_DEMON_HEAD, quantity = 1, 10)
+            obj(Items.GOLD_ORE, quantity = 1, 8)
+            obj(Items.LARRANS_KEY_23490, quantity = 1, 5)
+            obj(Items.UNCUT_SAPPHIRE, quantity = 1, 4)
+            obj(Items.FIRE_RUNE, quantity = 30, 4)
+            obj(Items.COINS, quantity = 450, 4)
+            obj(Items.COINS, quantity = 10, 4)
+            obj(Items.MITHRIL_SQ_SHIELD, quantity = 1, 4)
+            obj(Items.MITHRIL_CHAINBODY, quantity = 1, 4)
+            obj(Items.RUNE_MED_HELM, quantity = 1, 4)
+            obj(Items.UNCUT_EMERALD, quantity = 1, 2)
+            obj(Items.SLAYERS_ENCHANTMENT, quantity = 1, 2)
+            obj(Items.ANCIENT_SHARD, quantity = 1, 2)
+            obj(Items.DARK_TOTEM_BASE, quantity = 1, 1)
+            obj(Items.DARK_TOTEM_MIDDLE, quantity = 1, 1)
+            obj(Items.DARK_TOTEM_TOP, quantity = 1, 1)
+            obj(Items.UNCUT_RUBY, quantity = 1, 1)
+            obj(Items.GRIMY_GUAM_LEAF, quantity = 1, 1)
+        }
+    }
+
+scarredDemonTable.register(scarredDemonDrops, *scarredLesserDemonIds)
+
+on_npc_pre_death(*scarredLesserDemonIds) {
+    npc.damageMap.getMostDamage() as? Player
+}
+
+on_npc_death(*scarredLesserDemonIds) {
+    scarredDemonTable.getDrop(world, npc.damageMap.getMostDamage()!! as Player, npc.id, npc.tile)
+}
+
+scarredLesserDemonIds.forEach { id ->
+    set_combat_def(id) {
+        configs {
+            attackSpeed = 4
+            respawnDelay = 40
+            poisonChance = 0.0
+            venomChance = 0.0
+        }
+        stats {
+            hitpoints = 85
+            attack = 68
+            strength = 70
+            defence = 71
+            magic = 85
+            ranged = 1
+        }
+        bonuses {
+            defenceMagic = -10
+        }
+        anims {
+            attack = Animation.DEMON_ATTACK
+            block = Animation.DEMON_HIT
+            death = Animation.DEMON_DEATH
+        }
+        sound {
+            attackSound = Sound.DEMON_ATTACK
+            blockSound = Sound.DEMON_HIT
+            deathSound = Sound.DEMON_DEATH
+        }
+    }
+}

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/other/scarred_lesser_demon_combat.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/other/scarred_lesser_demon_combat.plugin.kts
@@ -13,7 +13,9 @@ import org.alter.api.HitType
 import org.alter.api.cfg.Animation
 import org.alter.api.cfg.Graphic
 import org.alter.api.cfg.Npcs
-
+val scarredLesserDemonIds = intArrayOf(
+    Npcs.SCARRED_LESSER_DEMON_12362
+)
 scarredLesserDemonIds.forEach { npcId ->
     on_npc_combat(npcId) {
         npc.queue {
@@ -44,7 +46,7 @@ fun bloodBurst(npc: Npc, target: Pawn) {
     val minHit = 5
     val maxHit = 21
     npc.prepareAttack(CombatClass.MAGIC, CombatStyle.MAGIC, AttackStyle.ACCURATE)
-    npc.animate(Animation.ANCIENT_SPELL_MULTI_CAST)
+    npc.animate(Animation.DEMON_ATTACK)
     val hitDelay = RangedCombatStrategy.getHitDelay(npc.getFrontFacingTile(target), target.getCentreTile()) - 1
     val accuracy = MagicCombatFormula.getAccuracy(npc, target)
     if (accuracy >= world.randomDouble()) {

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/other/scarred_lesser_demon_combat.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/other/scarred_lesser_demon_combat.plugin.kts
@@ -1,0 +1,62 @@
+package org.alter.plugins.content.npcs.other
+
+import org.alter.game.model.combat.AttackStyle
+import org.alter.game.model.combat.CombatClass
+import org.alter.game.model.combat.CombatStyle
+import org.alter.game.model.entity.Npc
+import org.alter.game.model.entity.Pawn
+import org.alter.game.model.queue.QueueTask
+import org.alter.plugins.content.combat.*
+import org.alter.plugins.content.combat.formula.MagicCombatFormula
+import org.alter.plugins.content.combat.strategy.RangedCombatStrategy
+import org.alter.api.HitType
+import org.alter.api.cfg.Animation
+import org.alter.api.cfg.Graphic
+import org.alter.api.cfg.Npcs
+
+scarredLesserDemonIds.forEach { npcId ->
+    on_npc_combat(npcId) {
+        npc.queue {
+            scarredLesserDemonCombat(this)
+        }
+    }
+}
+
+suspend fun scarredLesserDemonCombat(task: QueueTask) {
+    val npc = task.npc
+    var target = npc.getCombatTarget() ?: return
+
+    while (npc.canEngageCombat(target)) {
+        npc.facePawn(target)
+        if (npc.moveToAttackRange(task, target, distance = 8, projectile = true) && npc.isAttackDelayReady()) {
+            bloodBurst(npc, target)
+            npc.postAttackLogic(target)
+        }
+        task.wait(1)
+        target = npc.getCombatTarget() ?: break
+    }
+
+    npc.resetFacePawn()
+    npc.removeCombatTarget()
+}
+
+fun bloodBurst(npc: Npc, target: Pawn) {
+    val minHit = 5
+    val maxHit = 21
+    npc.prepareAttack(CombatClass.MAGIC, CombatStyle.MAGIC, AttackStyle.ACCURATE)
+    npc.animate(Animation.ANCIENT_SPELL_MULTI_CAST)
+    val hitDelay = RangedCombatStrategy.getHitDelay(npc.getFrontFacingTile(target), target.getCentreTile()) - 1
+    val accuracy = MagicCombatFormula.getAccuracy(npc, target)
+    if (accuracy >= world.randomDouble()) {
+        val damage = world.random(minHit..maxHit)
+        target.hit(damage = damage, type = HitType.HIT, delay = hitDelay)
+        target.graphic(id = Graphic.BLOOD_BURST_HIT, height = 124, delay = hitDelay)
+        val heal = damage / 4
+        if (heal > 0) {
+            npc.setCurrentHp((npc.getCurrentHp() + heal).coerceAtMost(npc.getMaxHp()))
+            npc.hit(heal, HitType.NPC_HEAL)
+        }
+    } else {
+        target.hit(damage = 0, type = HitType.BLOCK, delay = hitDelay)
+    }
+}


### PR DESCRIPTION
## Summary
- add drop tables and combat definitions for the Draynor necromancer and the Great Kourend variant
- configure infernal mages with rune-heavy loot and a Fire Blast combat script
- introduce ancient wizard mage and scarred lesser demon configs including Blood Burst behaviour

## Testing
- not run (Gradle wrapper not present)

------
https://chatgpt.com/codex/tasks/task_e_68e91201e30c832992d0c0d10b466588